### PR TITLE
Streamline console output

### DIFF
--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -174,7 +174,7 @@ impl DmiDecodeTable for DefaultDmiDecodeTable {
             Err(_) => {
                 let error: UnableToCollectDataError = UnableToCollectDataError {
                     message: format!(
-                        "\x1b[31mFATAL:\x1b[0m Unable to get dmidecode table '{}'!",
+                        "\x1b[31m[FATAL]\x1b[0m Unable to get dmidecode table '{}'!",
                         dmidecode_table
                     ),
                 };
@@ -229,7 +229,7 @@ impl DmiDecodeInformation for DefaultDmiDecodeInformation {
             Err(_) => {
                 let error: UnableToCollectDataError = UnableToCollectDataError {
                     message: format!(
-                        "\x1b[31mFATAL:\x1b[0m Unable to collect system information for '{}'!",
+                        "\x1b[31m[FATAL]\x1b[0m Unable to collect system information for '{}'!",
                         parameter
                     ),
                 };
@@ -289,13 +289,13 @@ fn dmidecode_system<T: DmiDecodeInformation>(_param: T) -> SystemInformation {
             }
             _ => {
                 println!(
-                    "INFO: Parameter {} not supported therefore not collected.",
+                    "\x1b[36m[info]\x1b[0m Parameter {} not supported therefore not collected.",
                     parameter
                 );
             }
         }
     }
-    println!("\x1b[32mSuccess:\x1b[0m System information collection completed.");
+    println!("\x1b[32m[success]\x1b[0m System information collection completed.");
     return system_information;
 }
 
@@ -330,13 +330,13 @@ fn dmidecode_chassis<T: DmiDecodeInformation>(_param: T) -> ChassisInformation {
             }
             _ => {
                 println!(
-                    "INFO: Parameter {} not supported. Therefore will not be collected.",
+                    "\x1b[36m[info]\x1b[0m Parameter {} not supported. Therefore will not be collected.",
                     parameter
                 );
             }
         }
     }
-    println!("\x1b[32mSuccess:\x1b[0m Chassis information collection completed.");
+    println!("\x1b[32m[success]\x1b[0m Chassis information collection completed.");
     return chassis_information;
 }
 
@@ -384,13 +384,13 @@ fn dmidecode_cpu<T: DmiDecodeTable>(_param: T) -> CpuInformation {
             Some(x) => {
                 key = x.to_string();
             }
-            None => println!("Info: Key not found at this location..."),
+            None => println!("\x1b[36m[info]\x1b[0m Key not found at this location..."),
         }
         match split.get(1) {
             Some(x) => {
                 value = x.to_string();
             }
-            None => println!("Info: Value not found at this location..."),
+            None => println!("\x1b[36m[info]\x1b[0m Value not found at this location..."),
         }
         match key.as_str() {
             "Version" => {
@@ -419,7 +419,7 @@ fn dmidecode_cpu<T: DmiDecodeTable>(_param: T) -> CpuInformation {
             }
         }
     }
-    println!("\x1b[32mSuccess:\x1b[0m CPU information collection completed.");
+    println!("\x1b[32m[success]\x1b[0m CPU information collection completed.");
     return cpu_information;
 }
 

--- a/src/collectors/network_collector.rs
+++ b/src/collectors/network_collector.rs
@@ -68,7 +68,7 @@ pub fn collect_network_information(
         Ok(network_interfaces) => {
             if network_interfaces.is_empty() {
                 return Err(collector_exceptions::NoNetworkInterfacesException {
-                    message: "Error: No network interfaces found!".to_string(),
+                    message: "\x1b[31m[error]\x1b[0m No network interfaces found!".to_string(),
                 });
             } else {
                 return Ok(network_interfaces);
@@ -77,7 +77,7 @@ pub fn collect_network_information(
         Err(_) => {
             let exc: collector_exceptions::UnableToCollectDataError =
                 collector_exceptions::UnableToCollectDataError {
-                    message: "FATAL: Unable to collect information about network interfaces!"
+                    message: "\x1b[31m[FATAL]\x1b[0m Unable to collect information about network interfaces!"
                         .to_string(),
                 };
             exc.abort(20);
@@ -105,7 +105,7 @@ pub fn construct_network_information(
         Ok(information) => information,
         Err(_) => {
             return Err(collector_exceptions::NoNetworkInterfacesException {
-                message: "Error: No network interfaces to process".to_string(),
+                message: "\x1b[31m[error]\x1b[0m No network interfaces to process".to_string(),
             });
         }
     };
@@ -189,7 +189,7 @@ pub fn construct_network_information(
                 // If a Network interface is completely missing an address block, it is assumed that it is invalid.
                 // This will raise a custom exception and cause the program to panic.
                 let exc = collector_exceptions::InvalidNetworkInterfaceError {
-                    message: "FATAL: A Network interface cannot be recognized!".to_string(),
+                    message: "\x1b[31m[FATAL]\x1b[0m A Network interface cannot be recognized!".to_string(),
                 };
                 exc.abort(25);
             }
@@ -199,7 +199,7 @@ pub fn construct_network_information(
         }
         interfaces.push(network_information)
     }
-    println!("\x1b[32mSuccess:\x1b[0m Network Interface collection completed.");
+    println!("\x1b[32m[success]\x1b[0m Network Interface collection completed.");
     return Ok(interfaces);
 }
 
@@ -279,7 +279,7 @@ fn build_interface_file_from_name(interface_name: &str) -> Result<std::fs::File,
         }
         Err(_) => {
             return Err(format!(
-                "\x1b[33mWARNING:\x1b[0m Speed file for interface '{}' does not exist.",
+                "\x1b[33m[warning]\x1b[0m Speed file for interface '{}' does not exist.",
                 interface_name
             ))
         }
@@ -305,14 +305,14 @@ fn collect_interface_speed(interface_name: &str, mut input: impl Read) -> Result
     match input.read_to_string(&mut network_speed) {
         Ok(_) => {}
         Err(err) => {
-            return Err(format!("\x1b[33mWARNING:\x1b[0m Unable to open speed file for interface '{}'. This may happen for the loopback or wireless devices. ({}))", interface_name, err));
+            return Err(format!("\x1b[33m[warning]\x1b[0m Unable to open speed file for interface '{}'. This may happen for the loopback or wireless devices. ({}))", interface_name, err));
         }
     };
     network_speed = network_speed.trim().replace("\n", "");
 
     if network_speed == "-1" {
         return Err(format!(
-            "\x1b[36mInfo:\x1b[0m No interface speed known for '{}'. The interface might be disabled.",
+            "\x1b[36m[info]\x1b[0m No interface speed known for '{}'. The interface might be disabled.",
             interface_name
         ));
     }
@@ -322,7 +322,7 @@ fn collect_interface_speed(interface_name: &str, mut input: impl Read) -> Result
             .parse::<u32>()
             .map_err(|e: std::num::ParseIntError| {
                 format!(
-                    "ERROR: Failed to parse speed as u32 for interface '{}': {}!",
+                    "\x1b[31m[error]\x1b[0m Failed to parse speed as u32 for interface '{}': {}!",
                     interface_name, e
                 )
             })?;
@@ -350,7 +350,7 @@ mod network_collector_tests {
             }
             Err(e) => match e {
                 collector_exceptions::NoNetworkInterfacesException { message } => {
-                    assert_eq!(message, "Error: No network interfaces found!".to_string());
+                    assert_eq!(message, "\x1b[31m[error]\x1b[0m No network interfaces found!".to_string());
                 }
             },
         }
@@ -413,7 +413,7 @@ mod network_collector_tests {
                 collector_exceptions::NoNetworkInterfacesException { message } => {
                     assert_eq!(
                         message,
-                        "Error: No network interfaces to process".to_string()
+                        "\x1b[31m[error]\x1b[0m No network interfaces to process".to_string()
                     );
                 }
             },
@@ -448,7 +448,7 @@ mod network_collector_tests {
         assert_eq!(
             result,
             Err(format!(
-                "\x1b[36mInfo:\x1b[0m No interface speed known for '{}'. The interface might be disabled.",
+                "\x1b[36m[info]\x1b[0m No interface speed known for '{}'. The interface might be disabled.",
                 interface_name
             )),
             "Test Scenario Failed (2): No error was raised by collect_interface_speed when passing speed = -1. The function did not identify the interface as disabled!"
@@ -467,7 +467,7 @@ mod network_collector_tests {
         assert_eq!(
             result,
             Err(format!(
-                    "ERROR: Failed to parse speed as u32 for interface '{}': cannot parse integer from empty string!",
+                    "\x1b[31m[error]\x1b[0m Failed to parse speed as u32 for interface '{}': cannot parse integer from empty string!",
                     interface_name
                 )),
             "Test Scenario Failed (3): No error was raised by collect_interface_speed when trying to parse an empty string into u32!"

--- a/src/collectors/network_collector.rs
+++ b/src/collectors/network_collector.rs
@@ -189,7 +189,8 @@ pub fn construct_network_information(
                 // If a Network interface is completely missing an address block, it is assumed that it is invalid.
                 // This will raise a custom exception and cause the program to panic.
                 let exc = collector_exceptions::InvalidNetworkInterfaceError {
-                    message: "\x1b[31m[FATAL]\x1b[0m A Network interface cannot be recognized!".to_string(),
+                    message: "\x1b[31m[FATAL]\x1b[0m A Network interface cannot be recognized!"
+                        .to_string(),
                 };
                 exc.abort(25);
             }
@@ -350,7 +351,10 @@ mod network_collector_tests {
             }
             Err(e) => match e {
                 collector_exceptions::NoNetworkInterfacesException { message } => {
-                    assert_eq!(message, "\x1b[31m[error]\x1b[0m No network interfaces found!".to_string());
+                    assert_eq!(
+                        message,
+                        "\x1b[31m[error]\x1b[0m No network interfaces found!".to_string()
+                    );
                 }
             },
         }

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -66,7 +66,7 @@ pub fn set_up_configuration(
         // TODO Rewrite validation logic to properly condition here
         match ConfigData::validate_config_file() {
             Ok(_) => {
-                println!("Configuration file \x1b[32mvalid\x1b[0m. Loading defaults...");
+                println!("\x1b[32m[success]\x1b[0m Configuration file \x1b[32mvalid\x1b[0m. Loading defaults...");
                 conf_data = ConfigData::read_config_file();
 
                 if uri.is_some() {
@@ -95,15 +95,15 @@ pub fn set_up_configuration(
         }
     }
 
-    println!("No config file found. Creating default...");
+    println!("\x1b[36m[info]\x1b[0m No config file found. Creating default...");
 
     match ConfigData::initialize_config_file() {
         Ok(_) => {
-            println!("\x1b[32mDefault configuration file created successfully.\x1b[0m")
+            println!("\x1b[32m[success]\x1b[0m Default configuration file created successfully.")
         }
         Err(_) => {
             let err = config_exceptions::UnableToCreateConfigError {
-                message: "\x1b[31mFATAL:\x1b[0m An error occurred while initializing the config!"
+                message: "\x1b[31m[FATAL]\x1b[0m An error occurred while initializing the config!"
                     .to_string(),
             };
             err.abort(12)
@@ -112,7 +112,7 @@ pub fn set_up_configuration(
 
     if uri.is_none() || token.is_none() {
         let err = config_exceptions::NoConfigError {
-            message: "\x1b[31mFATAL:\x1b[0m No configuration parameters found in CLI while using an empty config file!\nPlease enter valid configuration parameters in the configuration file or provide them via the CLI.".to_string()
+            message: "\x1b[31m[FATAL]\x1b[0m No configuration parameters found in CLI while using an empty config file!\nPlease enter valid configuration parameters in the configuration file or provide them via the CLI.".to_string()
         };
         err.abort(11)
     }
@@ -127,7 +127,7 @@ pub fn set_up_configuration(
         conf_data.device_role = device_role.unwrap();
     }
 
-    println!("\x1b[32mConfiguration loaded.\x1b[0m");
+    println!("\x1b[32m[success]\x1b[0m Configuration loaded.\x1b[0m");
     Ok(conf_data)
 }
 
@@ -167,7 +167,7 @@ fn get_config_dir() -> PathBuf {
     let home_dir: String = match std::env::var("HOME") {
         Ok(val) => val,
         Err(err) => {
-            panic!("FATAL: No $XDG_CONFIG_HOME variable found! ({})", err)
+            panic!("\x1b[31m[FATAL]\x1b[0m No $XDG_CONFIG_HOME variable found! ({})", err)
         }
     };
 
@@ -273,7 +273,7 @@ impl ConfigData {
             Ok(contents) => contents,
             Err(err) => {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
-                    message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
+                    message: format!("x1b[31m[FATAL]x1b[0m Unable to open config file! {}", err),
                 };
                 exc.abort(14)
             }
@@ -283,7 +283,7 @@ impl ConfigData {
             Ok(config) => config,
             Err(err) => {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
-                    message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
+                    message: format!("\x1b[31m[FATAL]\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
                 exc.abort(15)
             }
@@ -319,35 +319,35 @@ impl ConfigData {
 
         if config_parameters.netbox_uri.is_empty() {
             return Err(
-                "\x1b[31mValidation Error:\x1b[0m Config parameter 'netbox_uri' is empty! This parameter is mandatory."
+                "\x1b[31m[error]\x1b[0m Validation Error: Config parameter 'netbox_uri' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
 
         if config_parameters.netbox_api_token.is_empty() {
             return Err(
-                "\x1b[34mValidation Error:\x1b[0m Config parameter 'netbox_api_token' is empty! This parameter is mandatory."
+                "\x1b[31m[error]\x1b[0m Validation Error: Config parameter 'netbox_api_token' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
 
         if config_parameters.name.is_empty() {
             return Err(
-                "\x1b[34mValidation Error:\x1b[0m Config parameter 'name' is empty! This parameter is mandatory."
+                "\x1b[31m[error]\x1b[0m Validation Error: Config parameter 'name' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
 
         if config_parameters.system_location.is_empty() {
             return Err(
-                "\x1b[34mValidation Error:\x1b[0m Config parameter 'system_location' is empty! This parameter is mandatory."
+                "\x1b[31m[error]\x1b[0m Validation Error: Config parameter 'system_location' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
 
         if config_parameters.device_role.is_empty() {
             return Err(
-                "\x1b[34mValidation Error:\x1b[0m Config parameter 'device_role' is empty! This parameter is mandatory."
+                "\x1b[31m[error]\x1b[0m Validation Error: Config parameter 'device_role' is empty! This parameter is mandatory."
                     .to_string(),
             );
         }
@@ -366,7 +366,7 @@ impl ConfigData {
             Ok(contents) => contents,
             Err(err) => {
                 let exc: UnableToReadConfigError = config_exceptions::UnableToReadConfigError {
-                    message: format!("x1b[31mFATAL:x1b[0m Unable to open config file! {}", err),
+                    message: format!("\x1b[31m[FATAL]\x1b[0m Unable to open config file! {}", err),
                 };
                 exc.abort(14)
             }
@@ -376,7 +376,7 @@ impl ConfigData {
             Ok(config) => config,
             Err(err) => {
                 let exc: InvalidConfigFileError = config_exceptions::InvalidConfigFileError {
-                    message: format!("\x1b[31mFATAL:\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
+                    message: format!("\x1b[31m[FATAL]\x1b[0m Invalid config file syntax! Make sure the configuration file has valid TOML syntax. ({})", err),
                 };
                 exc.abort(15)
             }

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -167,7 +167,10 @@ fn get_config_dir() -> PathBuf {
     let home_dir: String = match std::env::var("HOME") {
         Ok(val) => val,
         Err(err) => {
-            panic!("\x1b[31m[FATAL]\x1b[0m No $XDG_CONFIG_HOME variable found! ({})", err)
+            panic!(
+                "\x1b[31m[FATAL]\x1b[0m No $XDG_CONFIG_HOME variable found! ({})",
+                err
+            )
         }
     };
 

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -50,7 +50,7 @@ pub fn probe(client: &ThanixClient) -> Result<(), NetBoxApiError> {
 
     match test_connection(&client) {
         Ok(()) => {
-            println!("\x1b[32mConnection established!\x1b[0m");
+            println!("\x1b[32m[success] Connection established!\x1b[0m");
             Ok(())
         }
         Err(err) => panic!("Client unable to reach NetBox! {}", err),


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

Just a small PR to somewhat streamline to terminal output of the application. Now every user relevant event has a `[status]` prefix. this should make it easier later on to find things in logs.

Example snippet:

![image](https://github.com/The-Nazara-Project/Nazara/assets/90576030/aa16bd6e-9a40-49a6-b381-3358ff3096e7)


Tick the applicable box:
- [ ] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [x] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: N/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE