### PR TITLE
Add device payload validation

### DIFF
--- a/src/publisher/trans_validation.rs
+++ b/src/publisher/trans_validation.rs
@@ -7,35 +7,14 @@
 //!
 //! * Confirming certain API objects (like IP Adresses) are in fact present in NetBox.
 //! * Validating that the Names of certain API objects are valid and correspond to an ID.
-//!
-use thanix_client::{types::WritableDeviceWithConfigContextRequest, util::ThanixClient};
-
-use crate::{configuration::config_parser::ConfigData, Machine};
+use thanix_client::{
+    types::{
+        WritableDeviceWithConfigContextRequest, WritableVirtualMachineWithConfigContextRequest,
+    },
+    util::ThanixClient,
+};
 
 use super::publisher_exceptions::PayloadValidationError;
-
-/// Validate the system information found in the config file.
-///
-/// Checks that parameters such as IDs and other system parameters entered in the config file
-/// correspond to an existing NetBox object.
-/// Otherwise, return an Error.
-///
-/// # Parameters
-///
-/// * state: `&ThanixClient` - The API client instance to use for communication.
-/// * config_data: `&ConfigData` - The configuration file contents.
-///
-/// # Returns
-///
-/// Returns `Ok(())` when all relevant config parameters correspond to existing objects. Otherwise
-/// return `Error`.
-///
-/// # Panics
-///
-/// This function panics if connection to NetBox fails.
-// pub fn validate_config_data(state: &ThanixClient, config_data: &ConfigData) -> Result<(), Error> {
-//     Ok(())
-// }
 
 /// Validate the `Device` Payload.
 ///
@@ -50,9 +29,35 @@ use super::publisher_exceptions::PayloadValidationError;
 /// # Panics
 ///
 /// This function panics if the connection to NetBox fails.
-pub fn validate_device_payload(state: &ThanixClient, payload: &WritableDeviceWithConfigContextRequest) -> Result<(), PayloadValidationError> {
+pub fn validate_device_payload(
+    state: &ThanixClient,
+    payload: &WritableDeviceWithConfigContextRequest,
+) -> Result<(), PayloadValidationError> {
     println!("Validating device payload...");
-    
+
     todo!("Device Payload validation not yet implemented!")
 }
 
+/// Validate the `VM` Payload.
+///
+/// # Parameters
+///
+/// * state: `&ThanixClient` - The ThanixClient instance to use for communication with NetBox.
+/// * payload: `&WritableVirtualMachineWithConfigContextRequest` - The payload to validate.
+///
+/// # Returns
+///
+/// Returns `Ok(())` when all relevant fields of the request payload are valid. Otherwise
+/// return `Err(PayloadValidationError)`.
+///
+/// # Panics
+///
+/// This function panics if the connection to NetBox fails.
+pub fn validate_vm_payload(
+    state: &ThanixClient,
+    payload: &WritableVirtualMachineWithConfigContextRequest,
+) -> Result<(), PayloadValidationError> {
+    println!("Validating VM payload...");
+
+    todo!("Virtual Machine payload validation not yet implemented!");
+}

--- a/src/publisher/trans_validation.rs
+++ b/src/publisher/trans_validation.rs
@@ -8,12 +8,11 @@
 //! * Confirming certain API objects (like IP Adresses) are in fact present in NetBox.
 //! * Validating that the Names of certain API objects are valid and correspond to an ID.
 //!
-//! > Also, given the filename here is room for a statement:
-//! > Trans rights are human rights!
-
 use thanix_client::{types::WritableDeviceWithConfigContextRequest, util::ThanixClient};
 
 use crate::{configuration::config_parser::ConfigData, Machine};
+
+use super::publisher_exceptions::PayloadValidationError;
 
 /// Validate the system information found in the config file.
 ///
@@ -41,15 +40,19 @@ use crate::{configuration::config_parser::ConfigData, Machine};
 /// Validate the `Device` Payload.
 ///
 /// # Parameters
-/// * payload: `WritableDeviceWithConfigContextRequest` - The struct to validate.
+///
+/// * payload: `&WritableDeviceWithConfigContextRequest` - The struct to validate.
 ///
 /// # Returns
 ///
 /// - Ok(())
-fn validate_device_payload(payload: WritableDeviceWithConfigContextRequest) -> bool {
+///
+/// # Panics
+///
+/// This function panics if the connection to NetBox fails.
+pub fn validate_device_payload(state: &ThanixClient, payload: &WritableDeviceWithConfigContextRequest) -> Result<(), PayloadValidationError> {
     println!("Validating device payload...");
-
-    todo!("Device payload validation not implemented yet!");
-
-    false
+    
+    todo!("Device Payload validation not yet implemented!")
 }
+


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

This PR adds the `trans_validation` module which provides logic to validate all request payloads before they are being sent. This is done to catch possible errors with user specified values beforehand and avoid unnecessary network traffic.

Of specific interest are IDs or Names of Device or VM fields, which are themselves API objects and need to be searched for.

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Tracks: #5, #56 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE