### PR TITLE
Implement linking of IP Adresses to newly created device.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Cargo.lock
 # output.txt file used for testing
 output.txt
 output.json
+
+# Test output
+test/manual/**/output/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "1.0.0"
+thanix_client = "1.1.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "2.0.1"
+thanix_client = "1.1.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "1.1.0"
+thanix_client = "2.0.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "1.1.0"
+# thanix_client = "1.1.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.
-# thanix_client = { package = "thanix_client", path = "path/to/your/crate" }
+thanix_client = { package = "thanix_client", path = "/home/christopher/Codebase/nazara-project/Thanix/output/" }
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "2.0.0"
+thanix_client = "2.0.1"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-# thanix_client = "1.1.0"
+thanix_client = "1.2.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.
-thanix_client = { package = "thanix_client", path = "/home/christopher/Codebase/nazara-project/Thanix/output/" }
+# thanix_client = { package = "thanix_client", path = "/path/to/your/crate" }
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ thanix_client = "1.1.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.
-# thanix_client = { package = "your_package_name", path = "path/to/your/client/crate" }
+# thanix_client = { package = "thanix_client", path = "path/to/your/crate" }
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/src/collectors/network_collector.rs
+++ b/src/collectors/network_collector.rs
@@ -67,11 +67,11 @@ pub fn collect_network_information(
     match network_interfaces_result {
         Ok(network_interfaces) => {
             if network_interfaces.is_empty() {
-                return Err(collector_exceptions::NoNetworkInterfacesException {
+                Err(collector_exceptions::NoNetworkInterfacesException {
                     message: "\x1b[31m[error]\x1b[0m No network interfaces found!".to_string(),
-                });
+                })
             } else {
-                return Ok(network_interfaces);
+                Ok(network_interfaces)
             }
         }
         Err(_) => {
@@ -114,6 +114,10 @@ pub fn construct_network_information(
     let mut network_information: NetworkInformation;
 
     for network_interface in raw_information {
+        // Skip loopback device.
+        if network_interface.name == "lo" {
+            continue;
+        }
         match Some(&network_interface.addr) {
             Some(_v) => {
                 // Cases where only one set of addresses exist.

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -59,13 +59,13 @@ use super::config_exceptions::{self, *};
 /// # Members
 /// - netbox: `NetBoxConfig` - Configuration parameters for the NetBox connection.
 /// - system: `SystemConfig` - Parameters abouth the system.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConfigData {
     pub netbox: NetboxConfig,
     pub system: SystemConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NetboxConfig {
     pub netbox_api_token: String,
     pub netbox_uri: String,
@@ -94,7 +94,7 @@ pub struct NetboxConfig {
 /// * tenant: `Option<i64>` - ID of tenant this device belongs to. (e.g: team or individual)
 /// * rack: `Option<i64>` - ID of the rack this device is located in.
 /// * position: `Option<i64>` - Position of the device within a rack if any.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SystemConfig {
     pub name: String,
     pub site_id: Option<i64>,

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -191,7 +191,7 @@ pub struct NwiConfig {
     pub mark_connected: bool,
     pub wireless_lans: Option<Vec<i64>>,
     pub vrf: Option<i64>,
-    pub custom_fields: Option<HashMap<String, Value, RandomState>>
+    pub custom_fields: Option<HashMap<String, Value, RandomState>>,
 }
 
 /// Set up configuration
@@ -487,7 +487,7 @@ impl ConfigData {
     /// * `config: ConfigData` - A `ConfigData` object.
     ///
     /// # Aborts
-    /// 
+    ///
     /// This function pay terminate the process if it cannot read the cofnig file.
     fn read_config_file() -> ConfigData {
         let mut file = match File::open(get_config_dir()) {

--- a/src/configuration/config_parser.rs
+++ b/src/configuration/config_parser.rs
@@ -63,6 +63,7 @@ use super::config_exceptions::{self, *};
 pub struct ConfigData {
     pub netbox: NetboxConfig,
     pub system: SystemConfig,
+    pub nwi: NwiConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -117,6 +118,80 @@ pub struct SystemConfig {
     pub location: Option<i64>,
     pub rack: Option<i64>,
     pub position: Option<i64>,
+}
+
+/// Information about the system's interface.
+///
+/// # Members
+///
+/// * name: `String` - The name of the interface.
+/// * id: `Option<i64>` - The ID of the interface, if it already exists. Mutually exclusive with
+/// name.
+/// * vdcs: `Option<Vec<i64>>`
+/// * module: `Option<i64>` - The module assigned to this interface.
+/// * label: `Option<String>` - The phyiscal label of this device if any.
+/// * r#type: `String` - The type of the interface (e.g. "bridge")
+/// * enabled: `bool` - Whether this device is enabled or not. Default: `True`.
+/// * parent: `Option<i64>` - ID of the parent interface if applicable.
+/// * bridge: `Option<i64>` - ID of the bridge device for this interface if applicable.
+/// * lag: `Option<i64>`
+/// * mtu: `Option<u32>`
+/// * duplex: `Option<String>`
+/// * wwn: `Option<String>`
+/// * mgmt_only: `bool` - Whether this interface may only be used for management. Default: `False`.
+/// * description: `Option<String>` - Optional description of the device.
+/// * mode: `Option<String>` - The mode this interface operates in.
+/// * rf_role: `Option<String>`
+/// * rf_channel: `Option<String>`
+/// * poe_mode: `Option<String>`
+/// * poe_type: `Option<String>`
+/// * rf_channel_frequency: `Option<f64>`
+/// * rf_channel_width: `Option<f64>`
+/// * poe_mode: `Option<String>` - The PoE mode of the interface.
+/// * poe_type: `Option<String>`
+/// * rf_channel_frequency: `Option<f64>`
+/// * rf_channel_width: `Option<f64>`
+/// * tx_power: `Option<u8>`
+/// * untagged_vlans: `Option<Vec<i64>>` - List of IDs of untagged VLANs assigned to this
+/// interface.
+/// * tagged_vlans: `Option<Vec<i64>>` - List of IDs of tagged VLANs assigned to this interface.
+/// * mark_connected: `bool` - Whether this interface is connected. Default: `True`.
+/// * wireless_lans: `Option<Vec<i64>>`
+/// * vrf: `Option<i64>`
+/// * custom_fields: `Option<Hashmap<String, Value, RandomState>>` - Any Custom fields you wish to
+/// add in form a of a Key-Value list.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NwiConfig {
+    pub name: Option<String>,
+    pub id: Option<i64>,
+    pub vdcs: Option<Vec<i64>>,
+    pub module: Option<i64>,
+    pub label: Option<String>,
+    #[serde(rename = "rtype")]
+    pub r#type: String, // I hate this field name, but that's what the openAPI schema said.
+    pub enabled: bool,
+    pub parent: Option<i64>,
+    pub bridge: Option<i64>,
+    pub lag: Option<i64>,
+    pub mtu: Option<u32>,
+    pub duplex: Option<String>,
+    pub wwn: Option<String>,
+    pub mgmt_only: bool,
+    pub description: Option<String>,
+    pub mode: Option<String>,
+    pub rf_role: Option<String>,
+    pub rf_channel: Option<String>,
+    pub poe_mode: Option<String>,
+    pub poe_type: Option<String>,
+    pub rf_channel_frequency: Option<f64>,
+    pub rf_channel_width: Option<f64>,
+    pub tx_power: Option<u8>,
+    pub untagged_vlans: Option<Vec<i64>>,
+    pub tagged_vlans: Option<Vec<i64>>,
+    pub mark_connected: bool,
+    pub wireless_lans: Option<Vec<i64>>,
+    pub vrf: Option<i64>,
+    pub custom_fields: Option<HashMap<String, Value, RandomState>>
 }
 
 /// Set up configuration
@@ -410,6 +485,10 @@ impl ConfigData {
     /// # Returns
     ///
     /// * `config: ConfigData` - A `ConfigData` object.
+    ///
+    /// # Aborts
+    /// 
+    /// This function pay terminate the process if it cannot read the cofnig file.
     fn read_config_file() -> ConfigData {
         let mut file = match File::open(get_config_dir()) {
             Ok(file) => file,

--- a/src/configuration/config_template.toml
+++ b/src/configuration/config_template.toml
@@ -44,3 +44,38 @@ platform = "x86_64"
 # collect_cpu_information = true
 #
 # collect_network_information = true
+
+[nwi]
+# name = "" # The name of your interface. Must correspond to an interface name present on this device.
+# id = 0 # The ID of the desired interface, if it already exists. (Mutually exclusive with name)
+# vdcs = []
+# module = 0
+# label = "" # The physical label on the interface or device, if applicable.
+# r#type = "" # The type of the interface (e.g "bridge")
+enabled = true # Whether this interface is enabled or not. Default: True.
+# parent = 0 # ID of the parent interface if applicable.
+# bridge = 0 # ID of the bridge device associated with this interface if applicable.
+# lag = 0
+# mtu = 0 # 32-bit unsigned interger!
+# duplex = ""
+# wwn = ""
+mgmt_only = false # Whether this interface shall be used for management only. (Default: False)
+# description = "" # Optional description of this interface.
+# mode = "" # Mode this interface operates in.
+# rf_role = ""
+# rf_channel = ""
+# poe_mode = ""
+# poe_type = ""
+# rf_channel_frequency = 0.0 # f64 value.
+# rf_channel_width = 0.0 # f64 value.
+# tx_power = 0 # u8 value
+# untagged_vlans = [] # List of IDs of the untagged VLANs associated to this interface.
+# tagged_vlans = [] # List of IDs of the tagged VLANs associated to this interfacce.
+mark_connected = true # Whether this interface is currently connected or not.
+# wireless_lans = [] # List of IDs of the wireless lans associated with this interface.
+# vrf = 0
+
+[nwi.custom_fields]
+# Custom fields of the interface go here.
+
+

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -2,4 +2,4 @@ pub mod api_client; // TODO make this non-public
 pub mod publisher;
 pub mod publisher_exceptions;
 pub mod trans_validation;
-pub mod translator; // make this not public // TODO make this non-public // TODO: make this non-public
+pub mod translator;

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -10,10 +10,12 @@ extern crate thanix_client;
 use reqwest::Error as ReqwestError;
 use thanix_client::{
     paths::{
-        dcim_devices_create, dcim_interfaces_create, dcim_interfaces_list, ipam_ip_addresses_create, DcimDevicesCreateResponse, DcimInterfacesListQuery
+        dcim_devices_create, dcim_interfaces_create, dcim_interfaces_list,
+        ipam_ip_addresses_create, DcimDevicesCreateResponse, DcimInterfacesListQuery,
     },
     types::{
-        Interface, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest
+        Interface, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest,
+        WritableInterfaceRequest,
     },
     util::ThanixClient,
 };
@@ -204,4 +206,3 @@ pub fn get_interface_by_name(
         }
     }
 }
-

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -9,8 +9,8 @@ extern crate thanix_client;
 
 use reqwest::{blocking::Client, Error as ReqwestError};
 use thanix_client::{
-    paths::{dcim_devices_create, DcimDevicesCreateResponse},
-    types::WritableDeviceWithConfigContextRequest,
+    paths::{dcim_devices_create, dcim_interfaces_create, DcimDevicesCreateResponse},
+    types::{WritableDeviceWithConfigContextRequest, WritableInterfaceRequest},
     util::ThanixClient,
 };
 
@@ -71,12 +71,11 @@ pub fn create_device(
         Ok(response) => {
             match response {
                 DcimDevicesCreateResponse::Http201(created_device) => {
-                    // TODO
                     println!(
-                        "\x1b[32m[success]\x1b[0m Device creation successful! New Device-ID {}.",
+                        "\x1b[32m[success]\x1b[0m Device creation successful! New Device-ID: '{}'.",
                         created_device.id
                     );
-                    return Ok(created_device.id);
+                    Ok(created_device.id)
                 }
                 DcimDevicesCreateResponse::Other(other_response) => {
                     // TODO
@@ -89,6 +88,46 @@ pub fn create_device(
         }
         Err(err) => {
             panic!("{}", err); // Handle this better
+        }
+    }
+}
+
+/// Create an interface object in NetBox.
+///
+/// # Parameters
+///
+/// * client: `&ThanixClient` - The client instance necessary for communication.
+/// * payload: `&WritableInterfaceRequest` - The payload for the API request.
+///
+/// # Returns
+///
+/// * `Ok(i64)` - The ID of the interface object.
+/// * `Err(NetBoxApiError)` - Error will be passed back to `publisher`.
+///
+/// # Panics
+///
+/// Panics if NetBox become unreachable.
+pub fn create_interface(
+    client: &ThanixClient,
+    payload: WritableInterfaceRequest,
+) -> Result<i64, NetBoxApiError> {
+    println!("Creating interface in NetBox...");
+
+    match dcim_interfaces_create(client, payload) {
+        Ok(response) => {
+            match response {
+                thanix_client::paths::DcimInterfacesCreateResponse::Http201(result) => {
+                    println!("\x1b[32m[success]\x1b[0m Interface created successfully. New Interface ID: {}", result.id);
+                    Ok(result.id)
+                }
+                thanix_client::paths::DcimInterfacesCreateResponse::Other(other_response) => {
+                    let exc: NetBoxApiError = NetBoxApiError::Other(other_response.text().unwrap());
+                    Err(exc)
+                }
+            }
+        }
+        Err(e) => {
+            panic!("[FATAL] NetBox connection failed. {}", e);
         }
     }
 }

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -9,7 +9,10 @@ extern crate thanix_client;
 
 use reqwest::{blocking::Client, Error as ReqwestError};
 use thanix_client::{
-    paths::{dcim_devices_create, dcim_interfaces_create, DcimDevicesCreateResponse},
+    paths::{
+        dcim_devices_create, dcim_interfaces_create, DcimDevicesCreateResponse,
+        DcimInterfacesCreateResponse,
+    },
     types::{WritableDeviceWithConfigContextRequest, WritableInterfaceRequest},
     util::ThanixClient,
 };
@@ -65,7 +68,7 @@ pub fn create_device(
     client: &ThanixClient,
     payload: &WritableDeviceWithConfigContextRequest,
 ) -> Result<i64, NetBoxApiError> {
-    println!("Creating Device in NetBox...");
+    println!("Creating device in NetBox...");
 
     match dcim_devices_create(client, payload.clone()) {
         Ok(response) => {
@@ -111,7 +114,7 @@ pub fn create_interface(
     client: &ThanixClient,
     payload: WritableInterfaceRequest,
 ) -> Result<i64, NetBoxApiError> {
-    println!("Creating interface in NetBox...");
+    println!("Creating network interface in NetBox...");
 
     match dcim_interfaces_create(client, payload) {
         Ok(response) => {
@@ -127,7 +130,9 @@ pub fn create_interface(
             }
         }
         Err(e) => {
-            panic!("[FATAL] NetBox connection failed. {}", e);
+            eprintln!("\x1b[33m[warning]\x1b[0m Error while decoding NetBox Response. This is probably still fine and a problem with NetBox.\nError: {}", e);
+            let exc = NetBoxApiError::Other(e.to_string());
+            Err(exc)
         }
     }
 }

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -14,7 +14,10 @@ use thanix_client::{
     util::ThanixClient,
 };
 
-use super::{publisher, publisher_exceptions};
+use super::{
+    publisher,
+    publisher_exceptions::{self, NetBoxApiError},
+};
 
 /// Tests connection to the NetBox API.
 ///
@@ -50,7 +53,18 @@ pub fn test_connection(client: &ThanixClient) -> Result<(), publisher_exceptions
     }
 }
 
-pub fn create_device(client: &ThanixClient, payload: &WritableDeviceWithConfigContextRequest) {
+/// Send request to create a new device in NetBox.
+///
+/// # Parameters
+///
+/// * client: `&ThanixClient` - The `ThanixClient` instance to use for communication.
+/// * payload: `&WritableDeviceWithConfigContextRequest` - The information about the device serving
+/// as a request body.
+///
+pub fn create_device(
+    client: &ThanixClient,
+    payload: &WritableDeviceWithConfigContextRequest,
+) -> Result<i64, NetBoxApiError> {
     println!("Creating Device in NetBox...");
 
     match dcim_devices_create(client, payload.clone()) {
@@ -59,8 +73,10 @@ pub fn create_device(client: &ThanixClient, payload: &WritableDeviceWithConfigCo
                 DcimDevicesCreateResponse::Http201(created_device) => {
                     // TODO
                     println!(
-                    "\x1b[32m[success] Device creation successful!\x1b[0m \n+++ Your machine can be found under the ID {}. +++", created_device.id
-                );
+                        "\x1b[32m[success]\x1b[0m Device creation successful! New Device-ID {}.",
+                        created_device.id
+                    );
+                    return Ok(created_device.id);
                 }
                 DcimDevicesCreateResponse::Other(other_response) => {
                     // TODO

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -10,9 +10,12 @@ extern crate thanix_client;
 use reqwest::{blocking::Client, Error as ReqwestError};
 use thanix_client::{
     paths::{
-        dcim_devices_create, dcim_interfaces_create, ipam_ip_addresses_create, DcimDevicesCreateResponse, DcimInterfacesCreateResponse
+        dcim_devices_create, dcim_interfaces_create, ipam_ip_addresses_create,
+        DcimDevicesCreateResponse, DcimInterfacesCreateResponse,
     },
-    types::{WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest},
+    types::{
+        WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest,
+    },
     util::ThanixClient,
 };
 
@@ -116,18 +119,16 @@ pub fn create_interface(
     println!("Creating network interface in NetBox...");
 
     match dcim_interfaces_create(client, payload) {
-        Ok(response) => {
-            match response {
-                thanix_client::paths::DcimInterfacesCreateResponse::Http201(result) => {
-                    println!("\x1b[32m[success]\x1b[0m Interface created successfully. New Interface ID: '{}'", result.id);
-                    Ok(result.id)
-                }
-                thanix_client::paths::DcimInterfacesCreateResponse::Other(other_response) => {
-                    let exc: NetBoxApiError = NetBoxApiError::Other(other_response.text().unwrap());
-                    Err(exc)
-                }
+        Ok(response) => match response {
+            thanix_client::paths::DcimInterfacesCreateResponse::Http201(result) => {
+                println!("\x1b[32m[success]\x1b[0m Interface created successfully. New Interface ID: '{}'", result.id);
+                Ok(result.id)
             }
-        }
+            thanix_client::paths::DcimInterfacesCreateResponse::Other(other_response) => {
+                let exc: NetBoxApiError = NetBoxApiError::Other(other_response.text().unwrap());
+                Err(exc)
+            }
+        },
         Err(e) => {
             eprintln!("\x1b[33m[warning]\x1b[0m Error while decoding NetBox Response while creating network interface. This is probably still fine and a problem with NetBox.\nError: {}", e);
             let exc = NetBoxApiError::Other(e.to_string());
@@ -142,20 +143,24 @@ pub fn create_interface(
 ///
 /// * client: `&ThanixClient` - The client instance necessary for communication.
 /// * payload: `&`
-pub fn create_ip(client: &ThanixClient, payload: WritableIPAddressRequest) -> Result<i64, NetBoxApiError> {
+pub fn create_ip(
+    client: &ThanixClient,
+    payload: WritableIPAddressRequest,
+) -> Result<i64, NetBoxApiError> {
     println!("Creating new IP address object...");
 
     match ipam_ip_addresses_create(client, payload) {
-        Ok(response) => {
-            match response {
-                thanix_client::paths::IpamIpAddressesCreateResponse::Http201(result) => {
-                    println!("\x1b[32m[success]\x1b[0m IP Address created successfully. New IP ID: '{}'", result.id);
-                    Ok(result.id)
-                }
-                thanix_client::paths::IpamIpAddressesCreateResponse::Other(other_response) => {
-                    let exc: NetBoxApiError = NetBoxApiError::Other(other_response.text().unwrap());
-                    Err(exc)
-                }
+        Ok(response) => match response {
+            thanix_client::paths::IpamIpAddressesCreateResponse::Http201(result) => {
+                println!(
+                    "\x1b[32m[success]\x1b[0m IP Address created successfully. New IP ID: '{}'",
+                    result.id
+                );
+                Ok(result.id)
+            }
+            thanix_client::paths::IpamIpAddressesCreateResponse::Other(other_response) => {
+                let exc: NetBoxApiError = NetBoxApiError::Other(other_response.text().unwrap());
+                Err(exc)
             }
         },
         Err(e) => {

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -10,13 +10,10 @@ extern crate thanix_client;
 use reqwest::Error as ReqwestError;
 use thanix_client::{
     paths::{
-        dcim_devices_create, dcim_interfaces_create, dcim_interfaces_list,
-        ipam_ip_addresses_create, DcimDevicesCreateResponse, DcimInterfacesCreateResponse,
-        DcimInterfacesListQuery,
+        dcim_devices_create, dcim_interfaces_create, dcim_interfaces_list, ipam_ip_addresses_create, DcimDevicesCreateResponse, DcimInterfacesListQuery
     },
     types::{
-        Interface, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest,
-        WritableInterfaceRequest,
+        Interface, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest
     },
     util::ThanixClient,
 };
@@ -120,7 +117,7 @@ pub fn create_interface(
     match dcim_interfaces_create(client, payload) {
         Ok(response) => match response {
             thanix_client::paths::DcimInterfacesCreateResponse::Http201(result) => {
-                println!("\x1b[32m[success]\x1b[0m Interface created successfully. New Interface ID: '{}'", result.id);
+                println!("\x1b[32m[success]\x1b[0m Interface created successfully. New Interface-ID: '{}'", result.id);
                 Ok(result.id)
             }
             thanix_client::paths::DcimInterfacesCreateResponse::Other(other_response) => {
@@ -152,7 +149,7 @@ pub fn create_ip(
         Ok(response) => match response {
             thanix_client::paths::IpamIpAddressesCreateResponse::Http201(result) => {
                 println!(
-                    "\x1b[32m[success]\x1b[0m IP Address created successfully. New IP ID: '{}'",
+                    "\x1b[32m[success]\x1b[0m IP Address created successfully. New IP-ID: '{}'",
                     result.id
                 );
                 Ok(result.id)
@@ -174,13 +171,16 @@ pub fn get_interface_by_name(
     state: &ThanixClient,
     payload: &WritableInterfaceRequest,
 ) -> Result<Interface, NetBoxApiError> {
-    println!("Trying to retrieve interface by name '{}'...", payload.name);
+    println!(
+        "Trying to retrieve interface by name '{}'...",
+        payload.name.as_ref().unwrap()
+    );
 
     match dcim_interfaces_list(state, DcimInterfacesListQuery::default()) {
         Ok(response) => {
             let interface_list: Vec<Interface> = match response {
                 thanix_client::paths::DcimInterfacesListResponse::Http200(interfaces) => {
-                    interfaces.results
+                    interfaces.results.unwrap()
                 }
                 thanix_client::paths::DcimInterfacesListResponse::Other(response) => {
                     let err: NetBoxApiError = NetBoxApiError::Other(response.text().unwrap());
@@ -195,7 +195,7 @@ pub fn get_interface_by_name(
             }
             Err(NetBoxApiError::Other(format!(
                 "No Inteface '{}' with name found. Creation possibly failed.",
-                payload.name
+                payload.name.as_ref().unwrap()
             )))
         }
         Err(e) => {
@@ -204,3 +204,4 @@ pub fn get_interface_by_name(
         }
     }
 }
+

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -6,7 +6,6 @@
 //!
 //! The actual request logic will be provided by the `thanix_client` crate.
 use std::process;
-
 /// TODO: 1. Implement Creation/update logic 2. Denest by splitting query logic off 3. Do not panic upon request fail
 use thanix_client::{
     paths::{

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -23,7 +23,7 @@ use thanix_client::{
 use crate::{
     configuration::config_parser::ConfigData,
     publisher::{
-        api_client::{create_device, test_connection},
+        api_client::{create_device, create_interface, test_connection},
         translator,
     },
     Machine,
@@ -88,6 +88,7 @@ pub fn register_machine(
                 todo!("Device update not yet implemented.") // TODO Implement machine update
             }
             None => {
+                // Creates Device. Will need to be updated after IP Adress creation.
                 let device_id = match create_device(client, &device_payload) {
                     Ok(id) => id,
                     Err(e) => {
@@ -95,6 +96,7 @@ pub fn register_machine(
                         process::exit(1);
                     }
                 };
+
                 let interface_payload: WritableInterfaceRequest =
                     translator::information_to_interface(
                         &client,
@@ -102,6 +104,14 @@ pub fn register_machine(
                         config_data.clone(),
                         &device_id,
                     );
+
+                let interface_id = match create_interface(client, interface_payload) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        println!("{}", e);
+                        process::exit(1);
+                    }
+                };
             }
         }
     }

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -108,7 +108,7 @@ pub fn register_machine(
                 let interface_id = match create_interface(client, interface_payload) {
                     Ok(id) => id,
                     Err(e) => {
-                        println!("{}", e);
+                        eprintln!("{}", e);
                         process::exit(1);
                     }
                 };

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -101,8 +101,8 @@ pub fn register_machine(
                 };
                 let interface_id: i64;
                 // TODO: Check if interface ID is valid, if not, create new interface.
-				// Create new interface object if no interface ID is given, or the given ID does
-				// not exist.
+                // Create new interface object if no interface ID is given, or the given ID does
+                // not exist.
                 if config_data.nwi.id.is_none() || !interface_exists(client, &config_data.nwi.id) {
                     let interface_payload: WritableInterfaceRequest =
                         translator::information_to_interface(

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -13,7 +13,7 @@ use thanix_client::{
         VirtualizationVirtualMachinesListQuery, VirtualizationVirtualMachinesListResponse,
     },
     types::{
-        self, DeviceWithConfigContext, VirtualMachineWithConfigContext,
+        DeviceWithConfigContext, VirtualMachineWithConfigContext,
         WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest,
     },
     util::ThanixClient,
@@ -144,14 +144,6 @@ pub fn register_machine(
     Ok(())
 }
 
-/// Creates a new machine in NetBox by calling the `translator` module to translate the `machine` parameter
-/// struct into the correct data type required by the API.
-fn create_machine(client: &ThanixClient, machine: &Machine) -> Result<(), NetBoxApiError> {
-    println!("Creating new machine in NetBox...");
-    // let payload = translator::information_to_device(machine);
-    Ok(())
-}
-
 /// Checks if a given network interface ID corresponds to a interface which already exsists.
 ///
 /// # Parameter
@@ -166,6 +158,13 @@ fn interface_exists(state: &ThanixClient, id: &Option<i64>) -> bool {
     todo!("check if interface exists must be implemented!");
 }
 
+// HACK
+/// Contingency function to search for the previously created Network Interface, when the response
+/// given my NetBox cannot be serialized correctly therefore no Interface ID is returned.
+///
+/// # Parameters
+/// * `state: &ThanixClient` - The client to communicate with the API.
+/// * `payload: &WritableInterfaceRequest` - The API request payload.
 fn cont_search_nwi(
     state: &ThanixClient,
     payload: &WritableInterfaceRequest,

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -64,7 +64,9 @@ pub fn probe(client: &ThanixClient) -> Result<(), NetBoxApiError> {
 ///
 /// # Parameters
 ///
-/// - `client: &ThanixClient` - Reference to a `thanix_client` instance
+/// - `client: &ThanixClient` - Reference to a `thanix_client` instance.
+/// - `machine: Machine` - Information about the host machine collected by the `collector` module.
+/// - `config_data: ConfigData` - Nazara's configuration.
 ///
 /// # Returns
 ///
@@ -99,10 +101,11 @@ pub fn register_machine(
                 };
                 let interface_id: i64;
                 // TODO: Check if interface ID is valid, if not, create new interface.
+				// Create new interface object if no interface ID is given, or the given ID does
+				// not exist.
                 if config_data.nwi.id.is_none() || !interface_exists(client, &config_data.nwi.id) {
                     let interface_payload: WritableInterfaceRequest =
                         translator::information_to_interface(
-                            &client,
                             &machine,
                             config_data.clone(),
                             &device_id,
@@ -129,9 +132,9 @@ pub fn register_machine(
                 }
 
                 let ip_payload: WritableIPAddressRequest =
-                    translator::information_to_ip(client, &machine, &config_data, interface_id);
+                    translator::information_to_ip(&machine, &config_data, interface_id);
 
-                let ip_id = match create_ip(client, ip_payload) {
+                let _ = match create_ip(client, ip_payload) {
                     Ok(id) => id,
                     Err(e) => {
                         eprintln!("{}", e);

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -14,7 +14,8 @@ use thanix_client::{
         VirtualizationVirtualMachinesListQuery, VirtualizationVirtualMachinesListResponse,
     },
     types::{
-        self, DeviceWithConfigContext, VirtualMachineWithConfigContext, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest
+        self, DeviceWithConfigContext, VirtualMachineWithConfigContext,
+        WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest,
     },
     util::ThanixClient,
 };
@@ -117,7 +118,8 @@ pub fn register_machine(
                     interface_id = config_data.nwi.id.unwrap();
                 }
 
-                let ip_payload: WritableIPAddressRequest = translator::information_to_ip(client, &machine, &config_data, interface_id);
+                let ip_payload: WritableIPAddressRequest =
+                    translator::information_to_ip(client, &machine, &config_data, interface_id);
 
                 let ip_id = match create_ip(client, ip_payload) {
                     Ok(id) => id,
@@ -126,7 +128,7 @@ pub fn register_machine(
                         process::exit(1);
                     }
                 };
-           }
+            }
         }
     }
     Ok(())
@@ -151,7 +153,7 @@ fn create_machine(client: &ThanixClient, machine: &Machine) -> Result<(), NetBox
 ///
 /// True/False depending on whether the interface exists.
 fn interface_exists(state: &ThanixClient, id: &Option<i64>) -> bool {
-   todo!("check if interface exists must be implemented!"); 
+    todo!("check if interface exists must be implemented!");
 }
 
 /// Get list of machines.

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -5,14 +5,13 @@
 //! TODO:
 //! - Identify primary IPv4 or IPv6 using the primary_network_interface field from `ConfigData`.
 use core::net::IpAddr;
-use std::net::Ipv4Addr;
 use std::process;
 use std::str::FromStr;
 use thanix_client::paths::{
     self, DcimPlatformsListQuery, DcimSitesListQuery, IpamIpAddressesListQuery,
 };
 use thanix_client::types::{
-    IPAddress, Platform, Site, WritableDeviceWithConfigContextRequest,
+    IPAddress, Platform, Site, WritableDeviceWithConfigContextRequest, WritableInterfaceRequest,
     WritableVirtualMachineWithConfigContextRequest,
 };
 use thanix_client::util::ThanixClient;
@@ -115,6 +114,7 @@ pub fn information_to_device(
     // payload.virtual_chassis = todo!();
     // payload.vc_position = todo!();
     // payload.vc_priority = todo!();
+    payload.tenant = config_data.system.tenant;
     payload.location = config_data.system.location;
 
     payload
@@ -135,9 +135,36 @@ pub fn information_to_device(
 pub fn information_to_vm(
     state: &ThanixClient,
     machine: &Machine,
-    config_data: &ConfigData,
+    config_data: ConfigData,
 ) -> WritableVirtualMachineWithConfigContextRequest {
     todo!("Translation of collected information to VM not implemented yet!")
+}
+
+/// Translate gathered information into a `WritableInterfaceRequest` payload.
+///
+/// # Parameters
+///
+/// * state: `&ThanixClient` - The client instance to be used for communication.
+/// * machine: `&Machine` - The collectedd information about the device or machine.
+/// * config_data: `ConfigData` - The configuration data.
+/// * device_id: `&i64` - The ID of the device that this interface belongs to.
+///
+/// # Returns
+///
+/// * payload: `WritableInterfaceRequest` - Payload for creating an interface.
+pub fn information_to_interface(
+    state: &ThanixClient,
+    machine: &Machine,
+    config_data: ConfigData,
+    device_id: &i64,
+) -> WritableInterfaceRequest {
+    println!("Creating Network Interface...");
+
+    let mut payload: WritableInterfaceRequest = WritableInterfaceRequest::default();
+
+    payload.device = device_id.to_owned();
+
+    payload
 }
 
 /// Returns the ID of the platform this machine uses.

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -157,7 +157,7 @@ pub fn information_to_interface(
 
     let mut payload: WritableInterfaceRequest = WritableInterfaceRequest::default();
 
-	payload.device = Some(device_id.to_owned());
+    payload.device = Some(device_id.to_owned());
     payload.name = config_data.system.primary_network_interface.clone();
 
     // FIXME:

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -163,6 +163,26 @@ pub fn information_to_interface(
     let mut payload: WritableInterfaceRequest = WritableInterfaceRequest::default();
 
     payload.device = device_id.to_owned();
+    // payload.vdcs = todo!();
+    // payload.module = todo!();
+    payload.name = match config_data.system.primary_network_interface {
+        Some(interface_name) => interface_name,
+        None => String::from("Nazara Generic Network Interface"),
+    };
+    // payload.label = todo!();
+    // payload.r#type = todo!();
+    // payload.parent = todo!();
+    // payload.bridge = todo!();
+    // payload.lag = todo!();
+    // payload.mtu = todo!();
+    payload.mac_address = todo!("Search for nwi specified as primary, get mac address.");
+    payload.speed = todo!();
+    payload.description = String::from("This interface was automatically created by Nazara.");
+    payload.mode = todo!();
+    payload.rf_role = todo!();
+    payload.rf_channel = todo!();
+    payload.poe_mode = todo!();
+    payload.poe_type = todo!();
 
     payload
 }
@@ -366,24 +386,24 @@ fn get_site_id(state: &ThanixClient, config_data: &ConfigData) -> Option<i64> {
     None
 }
 
-// Create a new IP-Adress object in NetBox if the collected IP Adresses for the preferred interface
-// do not exist yet.
-//
-// # Parameters
-//
-// * state: `&ThanixClient` - The `ThanixClient` object used for API connection.
-// * config_data: `&ConfigData` - The config information which identifies the preferred network
-// interface.
-// * sys_info: `&Machine` - Collected system information which contains the IP Adresses to create.
-//
-// # Returns
-//
-// Return `Ok(i64)` containing the ID of the created IP Adress entry if the creation was
-// successful. Otherwise, return `NetBoxApiError`.
-//
-// # Panics
-//
-// This function panics if the connection to NetBox fails.
+/// Create a new IP-Adress object in NetBox if the collected IP Adresses for the preferred interface
+/// do not exist yet.
+///
+/// # Parameters
+///
+/// * state: `&ThanixClient` - The `ThanixClient` object used for API connection.
+/// * config_data: `&ConfigData` - The config information which identifies the preferred network
+/// interface.
+/// * sys_info: `&Machine` - Collected system information which contains the IP Adresses to create.
+///
+/// # Returns
+///
+/// Return `Ok(i64)` containing the ID of the created IP Adress entry if the creation was
+/// successful. Otherwise, return `NetBoxApiError`.
+///
+/// # Panics
+///
+/// This function panics if the connection to NetBox fails.
 fn create_ip_adresses(
     state: &ThanixClient,
     config_data: &ConfigData,

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -12,7 +12,8 @@ use thanix_client::paths::{
     self, DcimPlatformsListQuery, DcimSitesListQuery, IpamIpAddressesListQuery,
 };
 use thanix_client::types::{
-    IPAddress, Platform, Site, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest, WritableVirtualMachineWithConfigContextRequest
+    IPAddress, Platform, Site, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest,
+    WritableInterfaceRequest, WritableVirtualMachineWithConfigContextRequest,
 };
 use thanix_client::util::ThanixClient;
 
@@ -220,7 +221,12 @@ pub fn information_to_interface(
 /// * machine: `&Machine` - Collected machine information.
 /// * config_data: `&ConfigData` - Data read from the config file.
 /// * interface_id: `i64` - ID of the network interface this IP belongs to.
-pub fn information_to_ip(state: &ThanixClient, machine: &Machine, config_data: &ConfigData, interface_id: i64) -> WritableIPAddressRequest {
+pub fn information_to_ip(
+    state: &ThanixClient,
+    machine: &Machine,
+    config_data: &ConfigData,
+    interface_id: i64,
+) -> WritableIPAddressRequest {
     println!("Creating IP Address payload...");
 
     let mut payload: WritableIPAddressRequest = WritableIPAddressRequest::default();

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -12,8 +12,7 @@ use thanix_client::paths::{
     self, DcimPlatformsListQuery, DcimSitesListQuery, IpamIpAddressesListQuery,
 };
 use thanix_client::types::{
-    IPAddress, Platform, Site, WritableDeviceWithConfigContextRequest, WritableInterfaceRequest,
-    WritableVirtualMachineWithConfigContextRequest,
+    IPAddress, Platform, Site, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest, WritableInterfaceRequest, WritableVirtualMachineWithConfigContextRequest
 };
 use thanix_client::util::ThanixClient;
 
@@ -209,6 +208,36 @@ pub fn information_to_interface(
     payload.custom_fields = config_data.nwi.custom_fields;
     payload.mark_connected = config_data.nwi.mark_connected;
     payload.enabled = config_data.nwi.enabled;
+
+    payload
+}
+
+/// Returns the payload necessary to create a new IP address.
+///
+/// # Parameters
+///
+/// * state: `&ThanixClient` - The client instance necessary for communication.
+/// * machine: `&Machine` - Collected machine information.
+/// * config_data: `&ConfigData` - Data read from the config file.
+/// * interface_id: `i64` - ID of the network interface this IP belongs to.
+pub fn information_to_ip(state: &ThanixClient, machine: &Machine, config_data: &ConfigData, interface_id: i64) -> WritableIPAddressRequest {
+    println!("Creating IP Address payload...");
+
+    let mut payload: WritableIPAddressRequest = WritableIPAddressRequest::default();
+
+    // payload.address = todo!();
+    // payload.vrf = todo!();
+    // payload.tenant = todo!();
+    // payload.status = todo!();
+    // payload.role = todo!();
+    // payload.assigned_object_type = todo!();
+    // payload.assigned_object_id = todo!();
+    // payload.nat_inside = todo!();
+    // payload.dns_name = todo!();
+    payload.description = String::from("This Address was automatically created by Nazara.");
+    payload.comments = String::from("Automatically created by Nazara. Dummy only.");
+    // payload.tags = todo!();
+    payload.custom_fields = Some(HashMap::new());
 
     payload
 }

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -172,11 +172,11 @@ pub fn information_to_interface(
     };
     // payload.label = todo!();
     // FIXME:
-    payload.r#type = String::from("bridge");
-    // payload.parent = todo!();
-    // payload.bridge = todo!();
-    // payload.lag = todo!();
-    // payload.mtu = todo!();
+    payload.r#type = config_data.nwi.r#type;
+    payload.parent = config_data.nwi.parent;
+    payload.bridge = config_data.nwi.bridge;
+    payload.lag = config_data.nwi.lag;
+    payload.mtu = config_data.nwi.mtu;
 
     // Get the interfce we are looking for as primary, then get its parameters.
     // These filter statements can probably be split off into their own function.
@@ -201,13 +201,14 @@ pub fn information_to_interface(
         None => None,
     };
     payload.description = String::from("This interface was automatically created by Nazara.");
-    // payload.mode = todo!();
-    // payload.rf_role = todo!();
-    // payload.rf_channel = todo!();
-    // payload.poe_mode = todo!();
-    // payload.poe_type = todo!();
-    // FIXME:
-    payload.custom_fields = Some(HashMap::new());
+    payload.mode = config_data.nwi.mode.unwrap_or(String::from(""));
+    payload.rf_role = config_data.nwi.rf_role.unwrap_or(String::from(""));
+    payload.rf_channel = config_data.nwi.rf_channel.unwrap_or(String::from(""));
+    payload.poe_mode = config_data.nwi.poe_mode.unwrap_or(String::from(""));
+    payload.poe_type = config_data.nwi.poe_type.unwrap_or(String::from(""));
+    payload.custom_fields = config_data.nwi.custom_fields;
+    payload.mark_connected = config_data.nwi.mark_connected;
+    payload.enabled = config_data.nwi.enabled;
 
     payload
 }

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -1,0 +1,6 @@
+# Manual Tests
+
+This directory contains scripts and files used to manually test Nazara or a given NetBox API.
+
+These can be used for sanity checking API responses to troubleshoot
+potential parsing errors.

--- a/test/manual/api/get_nazara_interface.sh
+++ b/test/manual/api/get_nazara_interface.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Test NetBox's API response by manually requesting information.
+# Must be run *after* running Nazara and registering your device.
+
+# USAGE:
+# ./test_interfaces.sh $URL $TOKEN
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <NetBox_URL> <Authorization_Token>"
+  exit 1
+fi
+
+url=$1
+token=$2
+
+
+curl -X POST "$url/api/dcim/interfaces/" \
+-H "Authorization: Token $token" \
+-H "Content-Type: application/json" \
+-d '{"name": "Nazara0", "device": 112, "type": "1000base-t"}' \
+-o "./output/interfaces.json"
+


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

Currently we can only create devices without the IP address fields being set.

This PR aims to fix that. For this, after device creation, we need to create an Interface for the device, create an IP address object and then PATCH the device with the ID of its primary IP address linked to one of its devices.

As references serve these threads:

https://github.com/netbox-community/netbox/discussions/8746

https://github.com/netbox-community/netbox/discussions/8837

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [x] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: #69 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE