### PR TITLE
Check if thanix_client and NetBox version are compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "1.2.0"
+thanix_client = "1.2.5"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
 
     match probe(&client) {
         Ok(()) => {}
-        Err(err) => println!("{}", err),
+        Err(err) => err.abort(None),
     };
 
     let dmi_information: dmi_collector::DmiInformation = dmi_collector::construct_dmi_information();

--- a/src/publisher/publisher.rs
+++ b/src/publisher/publisher.rs
@@ -56,7 +56,10 @@ pub fn probe(client: &ThanixClient) -> Result<(), NetBoxApiError> {
             println!("\x1b[32m[success] Connection established!\x1b[0m");
             Ok(())
         }
-        Err(err) => panic!("Client unable to reach NetBox! {}", err),
+        Err(err) => {
+            eprintln!("{}", err);
+            Err(err)
+        }
     }
 }
 

--- a/src/publisher/publisher_exceptions.rs
+++ b/src/publisher/publisher_exceptions.rs
@@ -6,12 +6,18 @@
 //!
 //! The publisher module uses error codes in the range of 30 - 39.
 //!
+//!	> [!Note]
+//!	> A lot of errors come from `thanix_client` and are being escalated without explicitly casting
+//!	> them into these custom types.
+//!
 //! |Code|Name   |Explanation|
 //! |----|-------|-----------|
-//! |`30`|--TBA--|--TBA--    |
-//! |`31`|--TBA--|--TBA--    |
-//! |`32`|--TBA--|--TBA--    |
-//! |`33`|--TBA--|--TBA--    |
+//! |`30`|ReqwestError|Implies an error with sending or receiving information to NetBox.|
+//! |`31`|JsonParse|Indicates erro while attempting to parse the JSON response.|
+//! |`32`|MissingVersion|Indicates that NetBox did not send the application version in the probing
+//! step.|
+//! |`33`|VersionMismatch|Indicates that the used `thanix_client` version is incompatible with
+//! NetBox.|
 //! |`34`|--TBA--|--TBA--    |
 //! |`35`|--TBA--|--TBA--    |
 //! |`36`|--TBA--|--TBA--    |
@@ -21,25 +27,57 @@
 //!
 
 use reqwest::Error as ReqwestError;
+use serde_json::Error as SerdeJsonError;
 
 use std::{error::Error, fmt, process};
 
+/// Variants of all Errors the API can encounter on Nazara's end.
+///
+/// # Variants:
+///
+/// * `Reqwest` - Wraps a `reqwest::Error`. Used for handling failures with requests and responses.
+/// * `VersionMismatch` - Used to indicate the `thanix_client` version is incompatible with NetBox.
+/// * `MissingVersion` - Used to indicate that NetBox's initial response does not contain the
+/// application version.
+/// * `JsonParse` - Wraps a `serde_json::Error`. Used to handle failures with response
+/// serialization.
+/// * `Other` - Expects a `String` message. Used for edge cases and general purpose error cases.
 #[derive(Debug)]
 pub enum NetBoxApiError {
     Reqwest(ReqwestError),
+    VersionMismatch(String),
+    MissingVersion(String),
+    JsonParse(SerdeJsonError),
     Other(String), // For other types of Errors, if necessary.
 }
 
 impl fmt::Display for NetBoxApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            NetBoxApiError::Reqwest(ref err) => write!(f, "Request error: {}", err),
-            NetBoxApiError::Other(ref err) => write!(f, "Error: {}", err),
+            NetBoxApiError::Reqwest(ref err) => write!(f, "[error] Request error: {}", err),
+            NetBoxApiError::VersionMismatch(ref err) => {
+                write!(f, "[error] API Client version error: {}", err)
+            }
+            NetBoxApiError::MissingVersion(ref err) => {
+                write!(f, "[error] API Client missing version error: {}", err)
+            }
+            NetBoxApiError::JsonParse(ref err) => write!(f, "[error] JSON parsing error: {}", err),
+            NetBoxApiError::Other(ref err) => write!(f, "[Error] {}", err),
         }
     }
 }
 
-impl Error for NetBoxApiError {}
+impl Error for NetBoxApiError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            NetBoxApiError::Reqwest(ref err) => Some(err),
+            NetBoxApiError::JsonParse(ref err) => Some(err),
+            NetBoxApiError::MissingVersion(_) => None,
+            NetBoxApiError::VersionMismatch(_) => None,
+            NetBoxApiError::Other(_) => None,
+        }
+    }
+}
 
 impl From<ReqwestError> for NetBoxApiError {
     fn from(err: ReqwestError) -> Self {
@@ -47,6 +85,51 @@ impl From<ReqwestError> for NetBoxApiError {
     }
 }
 
+impl From<SerdeJsonError> for NetBoxApiError {
+    fn from(err: SerdeJsonError) -> Self {
+        NetBoxApiError::JsonParse(err)
+    }
+}
+
+impl NetBoxApiError {
+    /// Abort the process, if necessary.
+    ///
+    /// If no `exit_code` is given, will try to detect one depending on the Error variant used.
+    ///
+    /// # Parameters
+    ///
+    /// * `&self`
+    /// * `exit_code: Option<i32>` - The code which the application should output when exiting. If
+    /// none, will try to detect it depending on the error variant.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return.
+    pub fn abort(&self, exit_code: Option<i32>) -> ! {
+        let code: i32;
+        if exit_code.is_none() {
+            code = self.figure_exit_code();
+        } else {
+            code = exit_code.unwrap();
+        }
+
+        eprintln!("{} (Error code: {})", self, code);
+        process::exit(code);
+    }
+
+    /// Detect exit code depending on the error type, if none is given to `abort()`.
+    fn figure_exit_code(&self) -> i32 {
+        match &self {
+            NetBoxApiError::Reqwest(_) => 30,
+            NetBoxApiError::JsonParse(_) => 31,
+            NetBoxApiError::MissingVersion(_) => 32,
+            NetBoxApiError::VersionMismatch(_) => 33,
+            NetBoxApiError::Other(_) => 34,
+        }
+    }
+}
+
+// TODO: Deprecate this.
 /// Error to be thrown when the validation of an API request payload fails.
 ///
 /// # Members


### PR DESCRIPTION
# What does this PR change?

Given that we have to run `thanix_client` with two versions - one for NetBox `v3.6.9` and one for `v4.x.x` we need to check, if the current version of NetBox is compatible with the used API client.

For this we have adjusted `Thanix` to also generate a custom `build.rs` for `thanix_client` together with a new `version.rs` module which contains the current version of the crate. 
(https://github.com/The-Nazara-Project/Thanix/commit/35ffbe1da6c187ddd891125f7e9e5325f84e40db)

The opening API request from Nazara's end is then on `$URL/api/status`. On this response, a simple check is run to determine, whether the `VERSION` constant from `thanix_client` and NetBox are compatible.

It is compatible, if:

- `thanix_client v1.x` is used with NetBox `v3.6.x`
- `thanix_client v2.x` is used with NetBox `v4.x.x`

For this

<!-- provide a short description what exactly your PR changes here -->

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: n/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- Code documentation present
<br/>

- [x] DONE