### PR TITLE
Overhaul config_parser error handling

### DIFF
--- a/src/configuration/config_exceptions.rs
+++ b/src/configuration/config_exceptions.rs
@@ -10,7 +10,7 @@
 //!
 //! |Code  |Name                    |Explanation                                                |
 //! |------|------------------------|-----------------------------------------------------------|
-//! |`10`  |ConfigFileError         |Indicates errors with operating on the config file.        |
+//! |`10`  |FileOpError             |Indicates errors with operating on the config file.        |
 //! |`11`  |NoConfigFileErrror      |Configuration file could not be found.                     |
 //! |`12`  |InvalidConfigFileError  |Contains a TOML-Deserialize error.                         |
 //! |`13`  |SerializationError      |Constains a TOML-Serialization error.                      |
@@ -132,113 +132,5 @@ impl ConfigError {
             ConfigError::MissingConfigOptionError(_) => 14,
             ConfigError::Other(_) => 19,
         }
-    }
-}
-
-/// This error is raised when the program cannot create a config file.
-///
-/// As a config file is required for the program's operation, it must abort.
-pub struct UnableToCreateConfigError {
-    pub message: String,
-}
-
-impl fmt::Display for UnableToCreateConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl UnableToCreateConfigError {
-    pub fn abort(&self, exit_code: i32) -> ! {
-        println!("{} (Error code: {})", self, exit_code);
-        process::exit(exit_code)
-    }
-}
-
-/// This exception is raised when the program cannot write to the config file.
-///
-/// E.g. when the user changes config parameters via the CLI.
-pub struct ConfigWriteException {
-    pub message: String,
-}
-
-impl fmt::Display for ConfigWriteException {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-/// This error is raised when the config fil cannot be read for an unknown reason.
-pub struct UnableToReadConfigError {
-    pub message: String,
-}
-
-impl fmt::Display for UnableToReadConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl UnableToReadConfigError {
-    pub fn abort(&self, exit_code: i32) -> ! {
-        println!("{} (Error code: {})", self, exit_code);
-        process::exit(exit_code)
-    }
-}
-
-/// This error is raised when the configuration file is not found.
-///
-/// This error is unrecoverable.
-pub struct NoConfigFileError {
-    pub message: String,
-}
-
-impl fmt::Display for NoConfigFileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl NoConfigFileError {
-    pub fn abort(&self, exit_code: i32) -> ! {
-        println!("{} (Error code: {})", self, exit_code);
-        process::exit(exit_code)
-    }
-}
-
-/// If the config file does not have valid syntax, the program mus abort and prompt
-/// the user to fix it.
-pub struct InvalidConfigFileError {
-    pub message: String,
-}
-
-impl fmt::Display for InvalidConfigFileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl InvalidConfigFileError {
-    pub fn abort(&self, exit_code: i32) -> ! {
-        println!("{} (Error code: {})", self, exit_code);
-        process::exit(exit_code)
-    }
-}
-
-/// If the config file is empty or contains empty fields, and no CLI parameters are given, this error shall be raised.
-pub struct NoConfigError {
-    pub message: String,
-}
-
-impl fmt::Display for NoConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl NoConfigError {
-    pub fn abort(&self, exit_code: i32) -> ! {
-        println!("{} (Error code: {})", self, exit_code);
-        process::exit(exit_code)
     }
 }


### PR DESCRIPTION
# What does this PR change?

This PR overhauls the error handling in the `config_parser` module to bring it in line with the other modules.

<!-- provide a short description what exactly your PR changes here -->

TODO:

- [x] Implement typed enum containing error variants (wrap source errors where applicable)
- [x] Implement all necessary traits (`std::error::Error`)
- [x] Implement `From` trait where applicable
- [x] Remove existing error types
- [x] Change return types and error checking in `config_parser.rs` proper.

Tick the applicable box:
- [ ] Add new feature
- [x] Feature changed
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: n/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE