### PR TITLE
Implement device update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,9 +1140,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thanix_client"
-version = "1.2.5"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbe7a49c7ccae747754ce55ca7d34c456f7b647b1d88d2164dcbbf3e820fbb"
+checksum = "20db507e07d9013d08cf2e5ed2f24722a925bff0da4ac1f3dace2e503d79fa6b"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,11 +1140,12 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thanix_client"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20db507e07d9013d08cf2e5ed2f24722a925bff0da4ac1f3dace2e503d79fa6b"
+checksum = "91a3a9304ed5af60160c6d64c141aae0d7036a7b7f5c02294677aa8557d114de"
 dependencies = [
  "chrono",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "1.3.0"
+thanix_client = "1.3.2"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.7.6"
 # This may not work in your environment. You can get your schema by visiting
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
-thanix_client = "1.2.5"
+thanix_client = "1.3.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,5 +118,8 @@ fn main() {
     }
 
     // Register the machine or VM with NetBox
-    let _ = register_machine(&client, machine, config);
+    match register_machine(&client, machine, config) {
+        Ok(_) => {}
+        Err(e) => e.abort(None),
+    };
 }

--- a/src/publisher/api_client.rs
+++ b/src/publisher/api_client.rs
@@ -11,9 +11,7 @@ use reqwest::Error as ReqwestError;
 use serde_json::Value;
 use thanix_client::{
     paths::{
-        dcim_devices_create, dcim_devices_update, dcim_interfaces_create, dcim_interfaces_list,
-        dcim_interfaces_retrieve, dcim_interfaces_update, ipam_ip_addresses_create,
-        DcimDevicesCreateResponse, DcimDevicesUpdateResponse, DcimInterfacesListQuery,
+        dcim_devices_create, dcim_devices_update, dcim_interfaces_create, dcim_interfaces_list, dcim_interfaces_retrieve, dcim_interfaces_update, ipam_ip_addresses_create, ipam_ip_addresses_update, DcimDevicesCreateResponse, DcimDevicesUpdateResponse, DcimInterfacesListQuery
     },
     types::{
         Interface, WritableDeviceWithConfigContextRequest, WritableIPAddressRequest,
@@ -235,8 +233,7 @@ pub fn create_interface(
             }
         },
         Err(e) => {
-            eprintln!("\x1b[33m[warning]\x1b[0m Error while decoding NetBox Response while creating network interface. This is probably still fine and a problem with NetBox.\nError: {}", e);
-            let exc = NetBoxApiError::Other(e.to_string());
+            let exc = NetBoxApiError::Reqwest(e);
             Err(exc)
         }
     }
@@ -245,14 +242,25 @@ pub fn create_interface(
 pub fn update_interface(
     client: &ThanixClient,
     payload: WritableInterfaceRequest,
-    device_id: i64,
     interface_id: i64,
 ) -> Result<i64, NetBoxApiError> {
-    println!(
-        "Updating interface '{}' belonging to device '{}'...",
-        interface_id, device_id
-    );
-    todo!("Interface update not yet implemented!");
+
+	match dcim_interfaces_update(client, payload, interface_id) {
+		Ok(response) => match response {
+			thanix_client::paths::DcimInterfacesUpdateResponse::Http200(result) => {
+				println!("\x1b[32m[success]\x1b[0m Interface '{}' updated successfully.", result.id);
+				Ok(result.id)
+			}
+			thanix_client::paths::DcimInterfacesUpdateResponse::Other(other) => {
+				let exc: NetBoxApiError = NetBoxApiError::Other(other.text().unwrap());
+				Err(exc)
+			}
+		},
+		Err(e) => {
+			let exc = NetBoxApiError::Reqwest(e);
+			Err(exc)
+		}
+	}
 }
 
 /// Create new IP adress object.
@@ -294,6 +302,36 @@ pub fn create_ip(
     }
 }
 
+/// Update a given IP address object.
+///
+/// # Parameters
+///
+/// * `client: &ThanixClient` - The API client instance to use.
+/// * `payload: WritableIPAddressRequest` - The API call payload.
+/// * `id: i64` - The ID of the IP Address to update.
+///
+/// # Returns
+///
+/// * `Ok(i64)` - The ID of the updated object.
+/// * `Err(NetBoxApiError)` - In case the connection fails or an unexpected response is returned.
+pub fn update_ip(client: &ThanixClient, payload: WritableIPAddressRequest, id: i64) -> Result<i64, NetBoxApiError> {
+	println!("Updating IPs for given interface...");
+
+	match ipam_ip_addresses_update(client, payload, id) {
+		Ok(response) => match response {
+			thanix_client::paths::IpamIpAddressesUpdateResponse::Http200(result) => Ok(result.id),
+			thanix_client::paths::IpamIpAddressesUpdateResponse::Other(other) => {
+				let exc: NetBoxApiError = NetBoxApiError::Other(other.text().unwrap());
+				Err(exc)
+			}
+		},
+		Err(e) => {
+			let exc: NetBoxApiError = NetBoxApiError::Reqwest(e);
+			Err(exc)
+		}
+	}
+}
+
 /// Get Interface by ID.
 ///
 /// # Parameters
@@ -326,6 +364,29 @@ pub fn get_interface(state: &ThanixClient, id: i64) -> Result<Interface, NetBoxA
             Err(err)
         }
     }
+}
+
+pub fn get_interface_list(state: &ThanixClient) -> Result<Option<Vec<Interface>>, NetBoxApiError> {
+	println!("Retrieving list of interfaces...");
+
+	match dcim_interfaces_list(state, DcimInterfacesListQuery::default()) {
+		Ok(response) => {
+			let interfaces = match response {
+				thanix_client::paths::DcimInterfacesListResponse::Http200(interfaces) => {
+					interfaces.results
+				},
+				thanix_client::paths::DcimInterfacesListResponse::Other(other) => {
+					let err: NetBoxApiError = NetBoxApiError::Other(other.text().unwrap());
+					return Err(err)
+				}
+			};
+			Ok(interfaces)
+		},
+		Err(e) => {
+			let err: NetBoxApiError = NetBoxApiError::Reqwest(e);
+			Err(err)
+		}
+	}
 }
 
 /// Attempt to retrieve an interface by its name.

--- a/test/manual/api/search_device.sh
+++ b/test/manual/api/search_device.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl 'https://netbox-test.suse.de/api/dcim/devices/?name=Nazara-Test-Internal&name__empty=false&serial=PF23BEBC&serial__empty=false' \
+  -H 'cookie: sessionid=kgpn9mre2fwsdlcowc6hq2anhih2ilfr'


### PR DESCRIPTION
# What does this PR change?

This PR adds Nazara's automatic update functionality for devices.

When Nazara is run, it checks whether the current device is already present in NetBox via several parameters. Until now, we focues on the use case of a new registration, failing when the device was already present.
Now, we can update an existing device and its interfaces and IP addresses.

The current approach is an absolutist one though. We will update every field.

Tick the applicable box:
- [x] Add new feature
- [ ] Security changes
- [ ] Tests
- [x] Documentation changed
<br/>

- [ ] General Maintenance

## TODO:

- [x]  Check if each IP address of the given interface exists (If yes: update, if no: create new)
- [x] Search for matching device (Name + Serial + MAC Address must match for certain match)

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: #57 
Tracks: #60 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- Documentation docstrings updated
<br/>

- [x] DONE