### PR TITLE
Parse DMI tables directly instead of using dmidecode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dmidecode"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82706a4bb0cc98a506c471ea366783bc8378f049fafb832c3b1cf2183757d96"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +835,7 @@ name = "nazara"
 version = "0.1.0-alpha.1"
 dependencies = [
  "clap",
+ "dmidecode",
  "mockall",
  "network-interface",
  "reqwest",
@@ -833,6 +843,7 @@ dependencies = [
  "serde_json",
  "thanix_client",
  "toml 0.7.8",
+ "uuid",
 ]
 
 [[package]]
@@ -1528,6 +1539,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ toml = "0.7.6"
 # https://your.netbox-instance.com/api/schema.
 # The yaml file will be downloaded and you can generate your client by using https://github.com/The-Nazara-Project/Thanix.
 thanix_client = "1.3.2"
+dmidecode = { version = "0.9.0", features = ["std"] }
+uuid = "1.17.0"
 # Uncomment this line if you are using a custom thanix client implementation.
 # Change the path to be relative to this Cargo.toml file.
 # The package parameter is the name of your client package. This is needed if you assigned a custom name upon creation.

--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -82,11 +82,30 @@ pub struct CpuInformation {
     pub status: String,
 }
 
-/// Construct [DmiInformation](struct.DmiInformation) out of the collected information.
+/// Construct [DmiInformation](struct.DmiInformation) instance by parsing SMBIOS and DMI tables
+/// from the system.
+///
+/// This function reads raw data from SMBIOS entry points and DMI tables and parses it into these
+/// structs:
+///
+/// - [SystemInformation](struct.SystemInformation) (vendor, model, sertial number, UUID, etc.)
+/// - [ChassisInformation](struct.ChassisInformation) (chassis type, asset tag, chassis serial no,
+/// etc.)
+/// - [CpuInformation](struct.CpuInformation) (core count, threads, speed, voltage and status)
+///
+/// Only the first available structure of each required type is used. For CPUs, only the structure
+/// marked as `CentralProcessor` is considered.
 ///
 /// # Returns
 ///
 /// An instance of the DmiInformation struct containing the collected system, chassis and cpu information.
+///
+/// # Errors
+///
+/// Returns a `Box<dyn Error>` if:
+/// - The SMBIOS header or DMI table cannot be read from filesystem.
+/// - The DMI entry point search fails.
+/// - Any of the required structures (system, chassis, CPU) are missing or malformed.
 pub fn construct_dmi_information() -> Result<DmiInformation, Box<dyn Error>> {
     println!("Collecting DMI Information...");
 

--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -177,7 +177,4 @@ pub fn construct_dmi_information() -> Result<DmiInformation, Box<dyn Error>> {
     })
 }
 
-#[cfg(test)]
-pub mod dmi_collector_tests {
-    // TODO
-}
+// NOTE: The dmidecode crate already handles malformed DMI information. Explicit tests are not needed.

--- a/src/collectors/dmi_collector.rs
+++ b/src/collectors/dmi_collector.rs
@@ -1,15 +1,11 @@
 //! ## Dmi Collector Module
 //!
 //! This module provides logic to collect and process system information by using dmidecode.
-//!
 
 use super::collector_exceptions::CollectorError;
-use super::util::{find_table, split_output};
+use dmidecode::{Structure, processor::ProcessorType};
 use serde::Serialize;
-use std::{
-    process::{Command, Output},
-    str::Split,
-};
+use std::{error::Error, fs};
 
 /// ## DmiInformation
 ///
@@ -84,485 +80,85 @@ pub struct CpuInformation {
     pub max_speed: String,
     pub voltage: String,
     pub status: String,
-    pub arch: Option<String>,
 }
-
-/// List of possible system parameters to collect dmi information from.
-///
-/// ## Members
-///
-/// * `system-manufacturer`
-/// * `system-product-name`
-/// * `system-uuid`
-/// * `system-serial-number`
-const POSSIBLE_SYSTEM_PARAMETERS: [&str; 4] = [
-    "system-manufacturer",
-    "system-product-name",
-    "system-uuid",
-    "system-serial-number",
-];
-
-/// List of possible chassis parameters to collect dmi information from.
-///
-/// ## Members
-///
-/// * `chassis-type`
-/// * `chassis-asset-tag`
-/// * `chassis-serial-number`
-const POSSIBLE_CHASSIS_PARAMETERS: [&str; 3] =
-    ["chassis-type", "chassis-asset-tag", "chassis-serial-number"];
 
 /// Construct [DmiInformation](struct.DmiInformation) out of the collected information.
 ///
 /// # Returns
 ///
 /// An instance of the DmiInformation struct containing the collected system, chassis and cpu information.
-pub fn construct_dmi_information() -> DmiInformation {
-    /*
-     * Return a new instance of DmiInformation joining all collected information.
-     *
-     * */
-    let dmi_information: DmiInformation = DmiInformation {
-        system_information: dmidecode_system(DefaultDmiDecodeInformation {}),
-        chassis_information: dmidecode_chassis(DefaultDmiDecodeInformation {}),
-        cpu_information: dmidecode_cpu(DefaultDmiDecodeTable {}),
-    };
-    dmi_information
-}
+pub fn construct_dmi_information() -> Result<DmiInformation, Box<dyn Error>> {
+    println!("Collecting DMI Information...");
 
-/// Represents the `get_dmidecode_table` function which, when called, returns the contents of the requested dmi table.
-trait DmiDecodeTable {
-    fn get_dmidecode_table(dmidecode_table: i32) -> String;
-}
+    // Get the SMBIOS header and DMI table from sysfs.
+    let buf = fs::read("/sys/firmware/dmi/tables/smbios_entry_point")?;
+    let dmi = fs::read("/sys/firmware/dmi/tables/DMI")?;
+    let entry = dmidecode::EntryPoint::search(&buf)?;
 
-/// Default implementation of the `get_dmidecode_table` functionality.
-struct DefaultDmiDecodeTable;
+    let mut system_information = None;
+    let mut chassis_information = None;
+    let mut cpu_information = None;
 
-/// Default implementation of the `get_dmidecode_table` function.
-impl DmiDecodeTable for DefaultDmiDecodeTable {
-    /// Executes `dmidecode` with a given table number.
-    ///
-    /// ## Arguments
-    ///
-    /// * dmidecode_table: i32 - The index of the table to return.
-    ///
-    /// ## Returns
-    ///
-    /// * String - The content of the dmi table as a string.
-    ///
-    /// ## Panics
-    ///
-    /// If `dmidecode -t <dmidecode_table>` fails, the function panics.
-    fn get_dmidecode_table(dmidecode_table: i32) -> String {
-        /*
-         * Collect DMI information from System.
-         *
-         * This function executes the dmidecode command for the table type provided.
-         */
-        let output: Output = match Command::new("sudo")
-            .arg("dmidecode")
-            .arg("-t")
-            .arg(dmidecode_table.to_string())
-            .output()
-        {
-            Ok(output) => output,
-            Err(e) => {
-                let err = CollectorError::DmiError(e.to_string());
-                err.abort(None);
+    // Iterate over the DMI tables.
+    for table in entry.structures(&dmi) {
+        match table? {
+            Structure::System(x) => {
+                system_information = Some(SystemInformation {
+                    vendor: x.manufacturer.to_owned(),
+                    model: x.product.to_owned(),
+                    // If we have a UUID, construct one from the buffer, otherwise an empty string.
+                    uuid: x
+                        .uuid
+                        .map_or_else(|| String::new(), |f| uuid::Uuid::from_bytes(f).to_string()),
+                    serial: x.serial.to_owned(),
+                    // TODO
+                    is_virtual: false,
+                })
             }
-        };
-
-        // Read the output of the command
-        return String::from_utf8_lossy(&output.stdout).to_string();
-    }
-}
-
-/// Implements a trait representing the `get_dmidecode_information` function.
-///
-/// This is needed mainly for testing `dmidecode_system` and `dmidecode_chassis` so we can implement two versions of this
-/// function. One with the real implementation and one returning the expected test values.
-trait DmiDecodeInformation {
-    fn get_dmidecode_information(parameter: &str) -> String;
-}
-
-/// Empty struct which implements the `DmiDecodeInformation` trait.
-struct DefaultDmiDecodeInformation;
-
-/// Implement the `DmiDecodeInformation` trait for the `DefaultDmiDecodeInformation` struct.
-///
-/// This represents the default implementation of the `get_dmidecode_information function.
-impl DmiDecodeInformation for DefaultDmiDecodeInformation {
-    /// Execute `dmidecode -s <PARAMETER>` where `<PARAMETER>` is the system property to look for.
-    ///
-    /// This method of obtaining system information is quicker than the other approach with crawling through the dmi tables.
-    /// It is only suitable for basic system information such as BIOS, platform and chassis information.
-    ///
-    /// ## Arguments
-    ///
-    /// * `parameter: &str` - The system property to look for.
-    ///
-    /// ## Returns
-    ///
-    /// * `String` - The system property
-    ///
-    /// ## Panics
-    ///
-    /// If the `dmidecode` execution fails, a `UnableToCollectDataError` is raised and the function panics.
-    fn get_dmidecode_information(parameter: &str) -> String {
-        let output: Output = match Command::new("sudo")
-            .arg("dmidecode")
-            .arg("-s")
-            .arg(parameter)
-            .output()
-        {
-            Ok(output) => output,
-            Err(e) => {
-                let err = CollectorError::DmiError(e.to_string());
-                err.abort(None);
+            Structure::Enclosure(x) => {
+                chassis_information = Some(ChassisInformation {
+                    chassis_type: x.enclosure_type.to_string(),
+                    asset: x.asset_tag_number.to_owned(),
+                    chassis_serial: x.serial_number.to_owned(),
+                })
             }
-        };
-        return String::from_utf8_lossy(&output.stdout).trim().to_string();
-    }
-}
-
-/// Collect general system information and construct a new [SystemInformation](struct.SystemInformation) object from it.
-///
-/// This function call the `get_dmidecode_information` function for each parameter required for system information.
-///
-/// If the system-manufacturer returns `QEMU` it is assumed that the machine is a virtual machine and the `is_virtual`
-/// field of [SystemInformation](struct.SystemInformation) is updated accordingly.
-///
-/// This is important as Virtual Machines and Physical Machines are treated differently by NetBox and are registered at
-/// different URLs.
-///
-/// Note: Fields *can* be empty strings if a parameter, that is being searched for, is not recognized in the match
-/// statement.
-///
-/// # Arguments
-///
-/// * `_param: T` - Receives an Object which implements the `DmiDecodeInformation` trait. Can be either the default
-/// implementation or a test implementation which returns expected values.
-///
-/// # Returns
-///
-/// * `system_information: SystemInformation`- A SystemInformation object.
-fn dmidecode_system<T: DmiDecodeInformation>(_param: T) -> SystemInformation {
-    println!("Collecting system information...");
-    let mut system_information: SystemInformation = SystemInformation {
-        vendor: String::new(),
-        model: String::new(),
-        uuid: String::new(),
-        serial: String::new(),
-        is_virtual: false,
-    };
-
-    for parameter in POSSIBLE_SYSTEM_PARAMETERS.iter() {
-        match *parameter {
-            "system-manufacturer" => {
-                system_information.vendor = T::get_dmidecode_information(parameter);
-
-                if system_information.vendor == "QEMU" {
-                    system_information.is_virtual = true;
+            Structure::Processor(x) => {
+                // There may be multiple processor tables. We only care about the CPU.
+                if x.processor_type != ProcessorType::CentralProcessor {
+                    continue;
                 }
+
+                cpu_information = Some(CpuInformation {
+                    version: String::new(),
+                    core_count: x.core_count.unwrap_or_default().to_string(),
+                    cores_enabled: x.core_enabled.unwrap_or_default().to_string(),
+                    thread_count: x.thread_count.unwrap_or_default().to_string(),
+                    max_speed: x.max_speed.to_string(),
+                    voltage: x.voltage.to_string(),
+                    // Fancy formatting for bitflags.
+                    status: format!("{:?}", x.status),
+                });
             }
-            "system-product-name" => {
-                system_information.model = T::get_dmidecode_information(parameter)
-            }
-            "system-uuid" => system_information.uuid = T::get_dmidecode_information(parameter),
-            "system-serial-number" => {
-                system_information.serial = T::get_dmidecode_information(parameter)
-            }
-            _ => {
-                println!(
-                    "\x1b[36m[info]\x1b[0m Parameter {} not supported therefore not collected.",
-                    parameter
-                );
-            }
+            _ => continue,
         }
     }
-    println!("\x1b[32m[success]\x1b[0m System information collection completed.");
-    system_information
-}
 
-/// Construct a ChassisInformation object by parsing the content of dmi chassis table.
-///
-/// # Arguments
-///
-/// * `_param: T` - Receives an Object which implements the `DmiDecodeInformation` trait. Can be either the default
-/// implementation or a test implementation which returns expected values.
-///
-/// # Returns
-///
-/// A ChassisInformation object.
-fn dmidecode_chassis<T: DmiDecodeInformation>(_param: T) -> ChassisInformation {
-    println!("Collecting chassis information...");
-    let mut chassis_information: ChassisInformation = ChassisInformation {
-        chassis_type: String::new(),
-        asset: String::new(),
-        chassis_serial: String::new(),
-    };
-
-    for parameter in POSSIBLE_CHASSIS_PARAMETERS.iter() {
-        match *parameter {
-            "chassis-type" => {
-                chassis_information.chassis_type = T::get_dmidecode_information(parameter)
-            }
-            "chassis-asset-tag" => {
-                chassis_information.asset = T::get_dmidecode_information(parameter)
-            }
-            "chassis-serial-number" => {
-                chassis_information.chassis_serial = T::get_dmidecode_information(parameter)
-            }
-            _ => {
-                println!(
-                    "\x1b[36m[info]\x1b[0m Parameter {} not supported. Therefore will not be collected.",
-                    parameter
-                );
-            }
-        }
-    }
-    println!("\x1b[32m[success]\x1b[0m Chassis information collection completed.");
-    chassis_information
-}
-
-/// Construct a CpuInformation object by parsing the content of dmi cpu table.
-///
-/// Captures the output of `dmidecode -t 4` and processes the table to find the required values.
-///
-/// # Returns
-///
-/// A CpuInformation object.
-fn dmidecode_cpu<T: DmiDecodeTable>(_param: T) -> CpuInformation {
-    println!("Collecting CPU information...");
-    let output: String = T::get_dmidecode_table(4);
-    let output_split: Split<'_, &str> = output.split("\n");
-    let mut split: Vec<&str>;
-
-    let mut cpu_information: CpuInformation = CpuInformation {
-        version: String::new(),
-        core_count: String::new(),
-        cores_enabled: String::new(),
-        thread_count: String::new(),
-        max_speed: String::new(),
-        voltage: String::new(),
-        status: String::new(),
-        arch: None,
-    };
-
-    let mut table_found: bool = false;
-
-    for part in output_split {
-        if !table_found {
-            table_found = find_table("Processor Information", part);
-        }
-
-        let split_output: Result<Vec<&str>, &str> = split_output(part);
-
-        match split_output {
-            Ok(_) => split = split_output.unwrap(),
-            Err(_) => continue,
-        }
-
-        let mut key: String = String::new();
-        let mut value: String = String::new();
-
-        match split.first() {
-            Some(x) => {
-                key = x.to_string();
-            }
-            None => println!("\x1b[36m[info]\x1b[0m Key not found at this location..."),
-        }
-        match split.get(1) {
-            Some(x) => {
-                value = x.to_string();
-            }
-            None => println!("\x1b[36m[info]\x1b[0m Value not found at this location..."),
-        }
-        match key.as_str() {
-            "Version" => {
-                cpu_information.version = value.trim().to_string();
-            }
-            "Core Count" => {
-                cpu_information.core_count = value.trim().to_string();
-            }
-            "Core Enabled" => {
-                cpu_information.cores_enabled = value.trim().to_string();
-            }
-            "Thread Count" => {
-                cpu_information.thread_count = value.trim().to_string();
-            }
-            "Max Speed" => {
-                cpu_information.max_speed = value.trim().to_string();
-            }
-            "Voltage" => {
-                cpu_information.voltage = value.trim().to_string();
-            }
-            "Status" => {
-                cpu_information.status = value.trim().to_string();
-            }
-            _ => {
-                continue;
-            }
-        }
-    }
-    cpu_information.arch = match get_architecture() {
-        Ok(arch) => Some(arch),
-        Err(e) => {
-            eprintln!("{}", e);
-            None
-        }
-    };
-    println!("\x1b[32m[success]\x1b[0m CPU information collection completed.");
-    cpu_information
-}
-
-/// Gets the architecture name through `uname`.
-///
-/// *This will override any information entered in the config file's `platform` field!*
-///
-/// # Returns
-/// - Ok(arch_name): `string` - Name of the CPU architecture.
-/// - Err(UnableToCollectDataError)
-fn get_architecture() -> Result<String, CollectorError> {
-    println!("Running uname to collect CPU architecture...");
-    let output = match Command::new("uname").arg("-p").output() {
-        Ok(output) => output,
-        Err(e) => {
-            let err = CollectorError::UnableToCollectDataError(format!(
-                "An error occured while attempting to execute `uname -p`! {}",
-                e
-            ));
-            return Err(err);
-        }
-    };
-
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok(DmiInformation {
+        system_information: system_information.ok_or(CollectorError::UnableToCollectDataError(
+            "Couldn't collect system information".to_owned(),
+        ))?,
+        chassis_information: chassis_information.ok_or(
+            CollectorError::UnableToCollectDataError(
+                "Couldn't collect chassis information".to_owned(),
+            ),
+        )?,
+        cpu_information: cpu_information.ok_or(CollectorError::UnableToCollectDataError(
+            "Couldn't collect CPU information".to_owned(),
+        ))?,
+    })
 }
 
 #[cfg(test)]
 pub mod dmi_collector_tests {
-    use super::*;
-    use std::any::Any;
-
-    /// Check a given value's type for being String or not.
-    ///
-    /// ## Returns
-    ///
-    /// * `bool` - True/False depending on if the given value is a String type.
-    fn is_string(value: &dyn Any) -> bool {
-        value.is::<String>()
-    }
-
-    /// Check a given value's type for being SystemInformation or not.
-    ///
-    /// ## Returns
-    ///
-    /// * `bool` - True/False depending on if the given value is a String type.
-    fn is_system_information(value: &dyn Any) -> bool {
-        value.is::<SystemInformation>()
-    }
-
-    /// Tests whether the `get_dmidecode_information` function panics when it tries to execute `dmidecode -s` with an
-    /// invalid parameter.
-    #[test]
-    #[should_panic]
-    fn test_get_dmidecode_information_panics() {
-        let result: Result<String, Box<dyn Any + Send>> = std::panic::catch_unwind(|| {
-            DefaultDmiDecodeInformation::get_dmidecode_information("invalid")
-        });
-
-        assert!(
-            result.is_err(),
-            "Test failure: get_dmidecode_information did not panic when supplied with an invalid
-        argument"
-        );
-    }
-
-    /// Test that `get_dmidecode_information` does not return an empty String. Validating that the given parameter is
-    /// valid.
-    #[test]
-    fn test_get_dmidecode_information_ok() {
-        let result: String =
-            DefaultDmiDecodeInformation::get_dmidecode_information("system-manufacturer");
-
-        assert!(
-            is_string(&result),
-            "Test failure: get_dmidecode_information did not return a String type!"
-        );
-        assert!(
-            !result.is_empty(),
-            "Test failure: get_dmidecode_information did return an empty string despite supplying a valid parameter!"
-        );
-    }
-
-    struct MockDmiDecodeInformation;
-
-    impl DmiDecodeInformation for MockDmiDecodeInformation {
-        fn get_dmidecode_information(parameter: &str) -> String {
-            match parameter {
-                "system-manufacturer" => "TEST".to_string(),
-                "system-product-name" => "TestMachine".to_string(),
-                "system-uuid" => "123456-123-1222".to_string(),
-                "system-serial-number" => "123456789".to_string(),
-                _ => String::new(),
-            }
-        }
-    }
-
-    #[test]
-    fn test_dmidecode_system() {
-        let expected_vendor: &str = "TEST";
-        let expected_model: &str = "TestMachine";
-        let expected_uuid: &str = "123456-123-1222";
-        let expected_serial: &str = "123456789";
-
-        // Mock existing get_dmidecode_information function return the expected parameters
-
-        let system_information: SystemInformation = dmidecode_system(MockDmiDecodeInformation {});
-
-        assert!(
-            is_system_information(&system_information),
-            "Test Failure: `dmidecode_system` did not return instance of `SystemInformation`!"
-        );
-        assert_eq!(system_information.vendor, expected_vendor);
-        assert_eq!(system_information.model, expected_model);
-        assert_eq!(system_information.uuid, expected_uuid);
-        assert_eq!(system_information.serial, expected_serial);
-    }
-
-    struct MockDmiDecodeTable;
-
-    impl DmiDecodeTable for MockDmiDecodeTable {
-        fn get_dmidecode_table(_dmidecode_table: i32) -> String {
-            let return_value: String = String::from(
-                "Processor Information\n\tSocket Designation: FP5\n\tType: Central Processor\n\tFamily: Zen\n\tManufacturer: Advanced Micro Devices, Inc\n\tVersion: AMD Ryzen 7 PRO 3700 w/ Radeon Vega Mobile Gfx\n\tVoltage: 1.2 V\n\tMax Speed: 4000 MHz\n\tCurrent Speed: 2300 MHz\n\tStatus: Populated, Enabled\n\tCore Count: 4\n\tCore Enabled: 4\n\tThread Count: 8",
-            );
-            return return_value;
-        }
-    }
-
-    #[test]
-    fn test_dmidecode_cpu() {
-        let expected: CpuInformation = CpuInformation {
-            version: "AMD Ryzen 7 PRO 3700 w/ Radeon Vega Mobile Gfx".to_string(),
-            core_count: "4".to_string(),
-            cores_enabled: "4".to_string(),
-            thread_count: "8".to_string(),
-            max_speed: "4000 MHz".to_string(),
-            voltage: "1.2 V".to_string(),
-            status: "Populated, Enabled".to_string(),
-            arch: Some("x86_64".to_string()),
-        };
-
-        let result = dmidecode_cpu(MockDmiDecodeTable {});
-
-        assert_eq!(expected.version, result.version);
-        assert_eq!(expected.core_count, result.core_count);
-        assert_eq!(expected.cores_enabled, result.cores_enabled);
-        assert_eq!(expected.thread_count, result.thread_count);
-        assert_eq!(expected.max_speed, result.max_speed);
-        assert_eq!(expected.voltage, result.voltage);
-        assert_eq!(expected.status, result.status);
-        assert_eq!(expected.arch, result.arch);
-    }
+    // TODO
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ use configuration::config_parser::set_up_configuration;
 use publisher::*;
 use reqwest::blocking::Client;
 use serde_json::Value;
-use std::{collections::HashMap, process};
+use std::{collections::HashMap, error::Error, process};
 use thanix_client::util::ThanixClient;
 
 /// The Machine struct
@@ -251,7 +251,7 @@ struct Args {
     plugin: Option<String>,
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let args: Args = Args::parse();
 
     let ascii_art = r#"
@@ -289,10 +289,11 @@ fn main() {
         Err(err) => err.abort(None),
     };
 
-    let dmi_information: dmi_collector::DmiInformation = dmi_collector::construct_dmi_information();
+    let dmi_information: dmi_collector::DmiInformation =
+        dmi_collector::construct_dmi_information()?;
 
     let network_information: Vec<NetworkInformation> =
-        network_collector::construct_network_information().unwrap();
+        network_collector::construct_network_information()?;
 
     let machine: Machine = Machine {
         name: args.name,

--- a/src/publisher/translator.rs
+++ b/src/publisher/translator.rs
@@ -51,25 +51,6 @@ pub fn information_to_device(
 ) -> WritableDeviceWithConfigContextRequest {
     println!("Creating Device object...");
 
-    let wanted_platform: Option<String> = if let Some(arch) =
-        machine.dmi_information.cpu_information.arch.as_ref()
-    {
-        println!(
-            "\x1b[36m[info]\x1b[0m CPU architecture was collected. Used by default, overriding possible config options..."
-        );
-        Some(arch.clone())
-    } else if let Some(config_value) = config_data.system.platform_name.as_ref() {
-        println!(
-            "\x1b[36m[info]\x1b[0m Architecture was not collected. Using config specifications..."
-        );
-        Some(config_value.clone())
-    } else {
-        println!(
-            "[\x1b[33m[warning]\x1b[0m No cpu architecture specified. Proceeding with 'none'..."
-        );
-        None
-    };
-
     let mut payload: WritableDeviceWithConfigContextRequest =
         WritableDeviceWithConfigContextRequest::default();
 
@@ -77,10 +58,7 @@ pub fn information_to_device(
     payload.device_type = config_data.system.device_type;
     payload.role = config_data.system.device_role;
     payload.tenant = config_data.system.tenant;
-    payload.platform = match wanted_platform {
-        Some(platform_name) => get_platform_id(state, platform_name),
-        None => None,
-    };
+    payload.platform = get_platform_id(state, std::env::consts::ARCH.to_owned());
     payload.serial = machine.dmi_information.system_information.serial.clone();
     // payload.asset_tag = todo!();
     payload.site = match get_site_id(state, &config_data) {


### PR DESCRIPTION
This PR replaces the manual `dmidecode` output parsing with a direct read of the SMBIOS/DMI table structures from the sysfs. This basically reads the same data as `dmidecode`, but without the need for multiple sub-shell `sudo dmidecode` invocations.