### PR TITLE
[Feature]: Implement `create` and `register` subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 futures = "0.3.31"
 rtnetlink = "0.16.0"
 reqwest = { version = "0.11.22", features = ["blocking", "json"] }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 <img src="https://github.com/user-attachments/assets/1a0ab81a-544f-45ef-a95d-46689a5ec922" alt="Alt Text" style="width:20%; height:auto;">
 
-Nazara is an experimental Rust program that automates the collection of system information for NetBox, using NetBox's
-API. It enables the automatic creation of new machines in NetBox or population of information fields for existing ones.
+Nazara is an experimental Rust program that automates the collection of system
+information for NetBox, using NetBox's API. It enables the automatic creation of
+new machines in NetBox or population of information fields for existing ones.
 
-**Nazara is in the early stages of its development. Please note that the information listed below is subject to change.**
+**Nazara is in the early stages of its development. Please note that the
+information listed below is subject to change.**
 
-> [!Note]
-> Nazara is currently in a beta state. Bugs are bound to happen. If you encounter any, please [report them](https://github.com/The-Nazara-Project/Nazara/issues).
+> [!Note] Nazara is currently in a beta state. Bugs are bound to happen. If you
+> encounter any, please
+> [report them](https://github.com/The-Nazara-Project/Nazara/issues).
 >
-> Furthermore, **Nazara currently does not support custom fields for any NetBox object**. Though, this is the next item on our agenda.
+> Furthermore, **Nazara currently does not support custom fields for any NetBox
+> object**. Though, this is the next item on our agenda.
 
 - [Compatibility](#compatibility)
 - [Installation](#installation)
@@ -24,14 +28,16 @@ API. It enables the automatic creation of new machines in NetBox or population o
 
 # Compatibility
 
-We strive to make sure to stay compatible with the most recent NetBox version. Here you can see which version of Nazara is compatible with which version of NetBox.
-When major ports to newer NetBox versions happen - which usually include breaking changes - the old version of Nazara will be moved to its own branch and tagged accordingly.
-
+We strive to make sure to stay compatible with the most recent NetBox version.
+Here you can see which version of Nazara is compatible with which version of
+NetBox. When major ports to newer NetBox versions happen - which usually include
+breaking changes - the old version of Nazara will be moved to its own branch and
+tagged accordingly.
 
 | Nazara Version   | NetBox Version | Branch            | maintained?        |
 | ---------------- | -------------- | ----------------- | ------------------ |
 | `v0.1.0_beta.2`  | `v4.3.x`       | `main`            | :white_check_mark: |
-| `v0.1.0_beta.1`  | `v4.3.x`       | `version/beta-1`  | :x: |
+| `v0.1.0_beta.1`  | `v4.3.x`       | `version/beta-1`  | :x:                |
 | `v0.1.0_alpha.2` | `v3.6.x`       | `version/alpha-2` | :x:                |
 
 Maintenance work on these older versions is not planned.
@@ -40,12 +46,15 @@ Maintenance work on these older versions is not planned.
 
 ## Building from source
 
-To use Nazara, you will need to have the Rust programming language and `cargo` installed. If you do not have them
-installed already, you can follow the instructions provided in the [official Rust documentation](https://www.rust-lang.org/tools/install).
+To use Nazara, you will need to have the Rust programming language and `cargo`
+installed. If you do not have them installed already, you can follow the
+instructions provided in the
+[official Rust documentation](https://www.rust-lang.org/tools/install).
 
-*Please note that this program only works on Linux systems.*
+_Please note that this program only works on Linux systems._
 
-Once you have everything installed, you can clone this repository and build the program by running the following commands:
+Once you have everything installed, you can clone this repository and build the
+program by running the following commands:
 
 ```bash
 git clone https://github.com/The-Nazara-Project/Nazara.git
@@ -55,39 +64,56 @@ cargo build --release
 
 This will create an executable file in the `target/release` directory.
 
-> [!Important]
-> Running Nazara stock will cause it to use our NetBox API reference client library [`thanix_client`](https://github.com/The-Nazara-Project/thanix_client).
-> This client was generated from the API spec of a stock NetBox instance (1.x from NetBox v3.6.9 and 2.x from NetBox 4.1.0).
-> If you encounter API request issues with your NetBox instance, you may need to generate your own using [`Thanix`](https://github.com/The-Nazara-Project/Thanix).
-
+> [!Important] Running Nazara stock will cause it to use our NetBox API
+> reference client library
+> [`thanix_client`](https://github.com/The-Nazara-Project/thanix_client). This
+> client was generated from the API spec of a stock NetBox instance (1.x from
+> NetBox v3.6.9 and 2.x from NetBox 4.1.0). If you encounter API request issues
+> with your NetBox instance, you may need to generate your own using
+> [`Thanix`](https://github.com/The-Nazara-Project/Thanix).
 
 ## Installation via `crates.io`
 
-Nazara is published on `crates.io`. If your operating system permits cargo to install packages globally, simply run `cargo install nazara` to install it.
+Nazara is published on `crates.io`. If your operating system permits cargo to
+install packages globally, simply run `cargo install nazara` to install it.
 
 # Usage
 
-To use Nazara, you will need to configure the URL of your NetBox API and provide an API token to the program by
-configuring all of these parameters inside the [configuration file](#configuring-via-nazaraconfigtomlfile).
+To use Nazara, you will need to configure the URL of your NetBox API and provide
+an API token to the program by configuring all of these parameters inside the
+[configuration file](#configuring-via-nazaraconfigtomlfile).
 
 After that, simply run
 
 ```bash
-sudo nazara
+nazara register
 ```
 
-in your terminal. Nazara will automatically collect all required system information and decide whether to create a new device, or update an existing entry.
+to register a new machine, or run
+
+```bash
+nazara update $MACHINE_ID
+```
+
+to update an existing one.
+
+in your terminal. Nazara will automatically collect all required system
+information and decide whether to create a new device, or update an existing
+entry.
 
 # Configuration
 
-Nazara supports two ways of providing configuration parameters: CLI arguments and a configuration file.
+Nazara supports two ways of providing configuration parameters: CLI arguments
+and a configuration file.
 
 Nazara accepts these parameters from you:
 
-- `-d, --dry-run`: Print all collected information without committing it to NetBox.
+- `-d, --dry-run`: Print all collected information without committing it to
+  NetBox.
 - `-u, --uri <URI>`: URI to your NetBox instance.
 - `-t, --token <TOKEN>`: Your API authentication token.
-- `-p, --plugin <PLUGIN>`: The path to a plugin script you want to use to fill in custom fields.
+- `-p, --plugin <PLUGIN>`: The path to a plugin script you want to use to fill
+  in custom fields.
 - `-h, --help`: Print help.
 - `-V, --version`: Print version.
 
@@ -99,60 +125,71 @@ Here is an example for passing these parameters on using the CLI:
 sudo nazara --uri <API_URL> --token <API_TOKEN> --name test_device
 ```
 
-When launching Nazara for the first time, a configuration file will be written at `$HOME/.config/nazara/config.toml`. If you pass CLI parameters, these will be automatically
-transfered into the config file as well.
+When launching Nazara for the first time, a configuration file will be written
+at `$HOME/.config/nazara/config.toml`. If you pass CLI parameters, these will be
+automatically transfered into the config file as well.
 
 ## Configuring via `$HOME/.config/nazara/config.toml` (recommended)
 
-Nazara's configuration must be located in the root user's home directory at `$HOME/.config/nazara/config.toml`.
+Nazara's configuration must be located in the root user's home directory at
+`$HOME/.config/nazara/config.toml`.
 
-When launching Nazara for the first time, it will write a stock config file to that path.
-Certain parameters are required to be configured there manually.
-You recognize them by their line not being commented out.
+When launching Nazara for the first time, it will write a stock config file to
+that path. Certain parameters are required to be configured there manually. You
+recognize them by their line not being commented out.
 
-Aside from the NetBox system parameters, configuration` via the `config.toml` also allows you to add certain
-custom fields to your system information that cannot be automatically selected. A great example would be the
-`System Location` entry. To specify that, simply add the parameter under the `[system]` block in your configuration file.
+Aside from the NetBox system parameters,
+configuration`via the`config.toml`also allows you to add certain
+custom fields to your system information that cannot be automatically selected. A great example would be the`System
+Location`entry. To specify that, simply add the parameter under the`[system]`
+block in your configuration file.
 
-> [!Note]
-> Currently, configuration by config file is the proper way to use Nazara given the amount of data required to register a machine.
-> We are investigating possibilities to make this less of a hassle.
-> In the meantime, we suggest you copy-paste the config between machines of the same type and function.
+> [!Note] Currently, configuration by config file is the proper way to use
+> Nazara given the amount of data required to register a machine. We are
+> investigating possibilities to make this less of a hassle. In the meantime, we
+> suggest you copy-paste the config between machines of the same type and
+> function.
 
 For an example config, check out `src/configuration/config_template.toml`
 
-*Please note that the following section is still a work in progress and all information is subject to change.*
+_Please note that the following section is still a work in progress and all
+information is subject to change._
 
 ## Configuring custom fields using user plugins
 
-Users are able to fill `custom_fields` parameters in their NetBox objects using custom bash scripts.
-These scripts should be placed inside the `$HOME/.config/nazara/scripts/` directory.
+Users are able to fill `custom_fields` parameters in their NetBox objects using
+custom bash scripts. These scripts should be placed inside the
+`$HOME/.config/nazara/scripts/` directory.
 
-These scripts can collect the desired information and output *a valid JSON representation* to `stdout`.
-Nazara then reads this output, validates it, and attempts to parse it to a `HashMap` of values.
+These scripts can collect the desired information and output _a valid JSON
+representation_ to `stdout`. Nazara then reads this output, validates it, and
+attempts to parse it to a `HashMap` of values.
 
-If everything works out, this will populate all of your custom fields no matter what fields you specified, as long as your script
-is correct.
+If everything works out, this will populate all of your custom fields no matter
+what fields you specified, as long as your script is correct.
 
-> [!Warning]
-> Users must make sure that the output of their scripts matches the name of their desired custom fields they specified
-> in NetBox.
+> [!Warning] Users must make sure that the output of their scripts matches the
+> name of their desired custom fields they specified in NetBox.
 >
-> Currently, **we only support text fields** as all the other field types would require smart parsing on our end.
-> We are currently investigating on how to achieve this.
+> Currently, **we only support text fields** as all the other field types would
+> require smart parsing on our end. We are currently investigating on how to
+> achieve this.
 
 # Contributing
 
-If you would like to contribute to Nazara, feel free to check the [contributing guide](./CONTRIBUTING.md) for
-information on our workflow and check the issues section for any open issue.
+If you would like to contribute to Nazara, feel free to check the
+[contributing guide](./CONTRIBUTING.md) for information on our workflow and
+check the issues section for any open issue.
 
 # License
 
 Nazara is released under the terms of the [GPL-v3.0](./LICENSE).
 
-By submitting a contribution to The Nazara Project, you agree that your contribution shall be licensed under the
-same license(s) as the project at the time of contribution.
+By submitting a contribution to The Nazara Project, you agree that your
+contribution shall be licensed under the same license(s) as the project at the
+time of contribution.
 
-You also grant the project maintainers the right to relicense the project, including your contribution, under any
-future version of those license(s), or under any other license that is free and open source software (FOSS) and
+You also grant the project maintainers the right to relicense the project,
+including your contribution, under any future version of those license(s), or
+under any other license that is free and open source software (FOSS) and
 compatible with the current license(s).

--- a/docs/src/contributors/test_environment.md
+++ b/docs/src/contributors/test_environment.md
@@ -56,10 +56,6 @@ Simply select a username and password of your wishes.
 ```admonish important
 Currently, the generation of the config file is still a bit wonky, so if it isnt generated upon first executing nazara, copy and paste
 the template from the README or `src/configuration/config_template.toml`.
-
-Also, despite my best efforts, the `primary_network_interface` field is still mandatory, even though it's not in the template.
-So, check your network interfaces and select the one you want to set as primary. Then add the config parameter to the `[system]`
-section at the bottom and paste the name of the interface as its value.
 ```
 
 Now it should work, if you have trouble setting it up, please reach out in the discussion section.

--- a/docs/src/users/configuration.md
+++ b/docs/src/users/configuration.md
@@ -7,17 +7,23 @@ Nazara accepts these parameters from you:
 - `-d, --dry-run`: Print all collected information without committing it to NetBox.
 - `-u, --uri <URI>`: URI to your NetBox instance.
 - `-t, --token <TOKEN>`: Your API authentication token.
-- `-n, --name <NAME>`: The name of the device.
 - `-p, --plugin <PLUGIN>`: The path to a plugin script you want to use to fill in custom fields.
 - `-h, --help`: Print help.
 - `-V, --version`: Print version.
+
+Afterwards, Nazara expects one of the following operation types to be specified:
+
+- `register`: Register a new device or vm in NetBox.
+- `update --id <device_id>`: To update an existing device or vm.
+- `auto`: Let Nazara decide based on the machine's name and serial number whether
+          registration or update is needed.
 
 ## Configuring via CLI
 
 Here is an example for passing these parameters on using the CLI:
 
 ```bash
-sudo nazara --uri <API_URL> --token <API_TOKEN> --name test_device . . .
+sudo nazara --uri <API_URL> --token <API_TOKEN> <OPERATION> . . .
 ```
 
 When launching Nazara for the first time, a configuration file will be written at `$HOME/.config/nazara/config.toml`.


### PR DESCRIPTION
<!--
By submitting a contribution to The Nazara Project, you agree that your contribution shall be licensed under the same license(s) as the project at the time of contribution.

You also grant the project maintainers the right to relicense the project, including your contribution, under any future version of those license(s), or under any other license that is free and open source software (FOSS) and compatible with the current license(s).
-->

# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

Implements `register` and `update` subcommands for Nazara to allow users to conduct each operation explicitly.

**This will deprecate the automatic detection logic.** We will keep it around, but its use is discouraged.

Tick the applicable box:
- [x] Add new feature
- [x] Behaviour change
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance


## Todos:

~~- [ ] Improve Error handling in Unexpected responses (avoid printing the whole response)~~ (split into issue)
- [x] Update documentation

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: #114 #115 

<!-- In case your changes track an existing EPIC or larger parent issue, link it below: -->
Tracks: #112 

<!-- Check this box if your PR fixes the issue(s) linked above -->
- [ ] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

Usage documentation will have to be adjusted.
<br/>

- [ ] DONE

<!--
By submitting a contribution to The Nazara Project, you agree that your contribution shall be licensed under the same license(s) as the project at the time of contribution.

You also grant the project maintainers the right to relicense the project, including your contribution, under any future version of those license(s), or under any other license that is free and open source software (FOSS) and compatible with the current license(s).
-->
